### PR TITLE
feat(web): engagement pack — minigames, progression & sidebar overhaul

### DIFF
--- a/web/assets/css/terminal.css
+++ b/web/assets/css/terminal.css
@@ -917,3 +917,194 @@ body[data-crt="on"] .tui-log {
     0%, 100% { opacity: 0.85; filter: brightness(0.95); text-shadow: 0 0 6px rgba(192, 132, 252, 0.3); }
     50%      { opacity: 1;    filter: brightness(1.15); text-shadow: 0 0 13px rgba(192, 132, 252, 0.6); }
 }
+
+/* ============================================================
+   Level-Up flash — a brief golden bloom over the whole shell
+   when the player's rank advances. Motion-gated; under reduced
+   motion the class is inert (the ::before only exists in the
+   no-preference block) so nothing flashes.
+   ============================================================ */
+.web-shell.fx-levelup { position: relative; }
+@media (prefers-reduced-motion: no-preference) {
+    @keyframes bc-levelup-flash {
+        0%   { opacity: 0; }
+        20%  { opacity: 1; }
+        100% { opacity: 0; }
+    }
+    .web-shell.fx-levelup::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        z-index: 40;
+        pointer-events: none;
+        background: radial-gradient(
+            ellipse at center,
+            rgba(251, 191, 36, 0.38) 0%,
+            rgba(251, 191, 36, 0.10) 45%,
+            rgba(251, 191, 36, 0) 75%
+        );
+        animation: bc-levelup-flash 900ms ease-out;
+    }
+}
+
+/* ============================================================
+   Damage flash — a brief red edge-pulse over the viewport when
+   the player takes a hit (HP drops). A transient full-screen
+   overlay element appended/removed by game.js. Motion-gated:
+   under reduced motion the element has no styling and is inert.
+   ============================================================ */
+.bc-screenflash {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    pointer-events: none;
+}
+@media (prefers-reduced-motion: no-preference) {
+    @keyframes bc-damage-flash {
+        0%   { opacity: 0; }
+        12%  { opacity: 1; }
+        100% { opacity: 0; }
+    }
+    .bc-screenflash-damage {
+        background: radial-gradient(
+            ellipse at center,
+            rgba(248, 113, 113, 0) 40%,
+            rgba(248, 113, 113, 0.5) 100%
+        );
+        animation: bc-damage-flash 600ms ease-out;
+    }
+}
+
+/* === Sidebar overhaul: inventory items, collapsible quest log, generative map === */
+
+/* Keep the map panel sized to its content; the whole .tui-sidebar scrolls. */
+.map-panel {
+    flex: 0 0 auto;
+}
+
+/* --- Inventory: vitals bar, then a clear carried-items list --- */
+.inv-hp {
+    margin: 0 0 0.4rem;
+}
+.inv-heading {
+    margin: 0.2rem 0 0.3rem;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.inv-items {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+.inv-items li {
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--accent-yellow);
+}
+.inv-empty {
+    margin: 0;
+    font-style: italic;
+}
+
+/* Label that marks the room's contents (distinct from carried inventory). */
+.room-contents-label {
+    margin: 0.35rem 0 0.15rem;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+/* --- Collapsible quest log --- */
+.quest-log {
+    margin-top: 0.5rem;
+    border-top: 1px solid var(--border-color);
+    padding-top: 0.4rem;
+}
+.quest-log > summary {
+    cursor: pointer;
+    list-style: none;
+    font-size: 0.78rem;
+    color: var(--accent-blue);
+    user-select: none;
+}
+.quest-log > summary::-webkit-details-marker {
+    display: none;
+}
+.quest-log > summary::before {
+    content: "▸ ";
+    color: var(--text-secondary);
+}
+.quest-log[open] > summary::before {
+    content: "▾ ";
+}
+.quest-log > summary:hover {
+    color: var(--accent-purple);
+}
+.ql-group {
+    margin: 0.5rem 0 0.2rem;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.ql-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.12rem;
+}
+.ql-list li {
+    font-size: 0.82rem;
+    line-height: 1.3;
+}
+.ql-done {
+    color: var(--accent-green);
+}
+.ql-active {
+    color: var(--accent-yellow);
+    font-weight: 700;
+}
+.ql-locked,
+.ql-side {
+    color: var(--text-secondary);
+}
+
+/* --- Generative dungeon map (fog-of-war tree) --- */
+.map-tree {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    line-height: 1.35;
+    white-space: pre;
+    overflow-x: auto;
+    color: var(--text-secondary);
+}
+.map-tree .map-seen {
+    color: var(--accent-blue);
+}
+.map-tree .map-here {
+    color: var(--accent-yellow);
+    font-weight: 700;
+}
+.map-tree .map-fog {
+    color: var(--text-secondary);
+    opacity: 0.55;
+}
+.map-legend {
+    margin: 0.4rem 0 0;
+    font-size: 0.7rem;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .map-tree .map-here {
+        text-shadow: 0 0 6px rgba(251, 191, 36, 0.45);
+    }
+}

--- a/web/assets/css/terminal.css
+++ b/web/assets/css/terminal.css
@@ -845,9 +845,14 @@ body[data-crt="on"] .tui-log {
         }
     }
 }
+/* Sweep stays within [0%, 100%]: with background-size:220% and no-repeat,
+   any position outside this range leaves part of the text uncovered by the
+   gradient, which (because text-fill is transparent) makes those glyphs
+   vanish mid-animation. Both endpoints render all-yellow (the green shine
+   sits just off-screen), so the loop repeats seamlessly with no jump. */
 @keyframes bc-banner-sweep {
-    from { background-position: 140% 0; }
-    to   { background-position: -40% 0; }
+    from { background-position: 100% 0; }
+    to   { background-position: 0% 0; }
 }
 
 /* (2) ROOM VIGNETTE — small ASCII mascot below the Location panel. */

--- a/web/assets/js/game.js
+++ b/web/assets/js/game.js
@@ -10,6 +10,7 @@
         quest: document.getElementById("quest-panel"),
         inventory: document.getElementById("inventory-panel"),
         room: document.getElementById("room-panel"),
+        map: document.getElementById("map-panel"),
         log: document.getElementById("output-log"),
         prompt: document.getElementById("prompt-label"),
         input: document.getElementById("command-input"),
@@ -104,6 +105,18 @@
         const safe = art.map(escapeHtml).join("\n");
         return `<pre class="room-vignette" data-room-art="${key}" aria-hidden="true">${safe}</pre>`;
     }
+
+    // Optional side objectives, grounded in real, checkable state: each hidden
+    // area is "done" once the player has revealed it (reveals map a visible path
+    // like /entrance/chapel to its dotted source). Kept separate from the main
+    // story chain so the quest log can show both tracks. Declared up here so it
+    // is initialized before the first render() during init.
+    const SIDE_QUESTS = [
+        { key: "chapel", name: "The Hidden Chapel", hint: "Search for a dotfile and unlock the chapel with grep." },
+        { key: "vault", name: "The Sealed Vault", hint: "Use variables to breach the vault." },
+        { key: "scrap", name: "The Scrapyard", hint: "Find the scrap and master symbolic links." },
+        { key: "rift", name: "The Rift", hint: "Tear open the rift for advanced trials." },
+    ];
 
     const logLines = [];
     const BANNER = [
@@ -231,6 +244,10 @@
                 docsPanel.setData(data.docs, runtime);
                 window.BashcrawlStorage.clear();
             }
+            if (out.action === "levelup") {
+                flashLevelUp();
+                continue;
+            }
             append(out.kind, out.text || "");
         }
         const after = snapshotState();
@@ -248,6 +265,7 @@
         if (next.hp < prev.hp) {
             shakePanel(dom.inventory);
             applyHeroMood("hurt");
+            screenFlash("damage");
         }
         if (next.xp > prev.xp) {
             popXp();
@@ -271,6 +289,28 @@
         append("art", lines);
     }
 
+    // Brief full-screen flash via a transient overlay element (no pseudo-element
+    // conflicts with the CRT/level-up layers). Auto-removed; reduced-motion-safe.
+    function screenFlash(kind) {
+        const el = document.createElement("div");
+        el.className = `bc-screenflash bc-screenflash-${kind}`;
+        el.setAttribute("aria-hidden", "true");
+        document.body.appendChild(el);
+        let done = false;
+        const cleanup = () => { if (done) return; done = true; el.remove(); };
+        el.addEventListener("animationend", cleanup, { once: true });
+        setTimeout(cleanup, 1000);
+    }
+
+    function flashLevelUp() {
+        const shell = document.querySelector(".web-shell");
+        if (!shell) return;
+        shell.classList.remove("fx-levelup");
+        void shell.offsetWidth;
+        shell.classList.add("fx-levelup");
+        setTimeout(() => shell.classList.remove("fx-levelup"), 950);
+    }
+
     function flashPanel(el) {
         if (!el || !el.parentElement) return;
         const target = el.closest(".tui-panel") || el;
@@ -290,7 +330,7 @@
     }
 
     function popXp() {
-        const xpSpan = dom.quest.querySelector(".kind-dim");
+        const xpSpan = dom.quest.querySelector(".quest-xp") || dom.quest.querySelector(".kind-dim");
         if (!xpSpan) return;
         xpSpan.classList.remove("fx-pop");
         void xpSpan.offsetWidth;
@@ -312,27 +352,84 @@
     }
 
     function render() {
+        recordVisit();
         renderQuest();
         renderInventory();
         renderHpBar();
         renderRoom();
+        renderMap();
         renderPrompt();
         renderLog();
+    }
+
+    // Record the current room (and its ancestors, so the trunk is always solid)
+    // into the persisted visited-set that drives the generative map's fog of war.
+    function recordVisit() {
+        const visited = runtime.state.visited || (runtime.state.visited = []);
+        const seen = new Set(visited);
+        const parts = runtime.state.cwd.split("/").filter(Boolean);
+        let acc = "";
+        for (const part of parts) {
+            acc += "/" + part;
+            if (!seen.has(acc)) { visited.push(acc); seen.add(acc); }
+        }
+    }
+
+    function sideQuestDone(key) {
+        const reveals = runtime.state.reveals || {};
+        return Object.keys(reveals).some((path) => path.endsWith("/" + key));
+    }
+
+    function questStatus(quest) {
+        if (runtime.state.completedQuestIds.includes(quest.id)) return "done";
+        if (quest.id === runtime.state.currentQuestId) return "active";
+        return "locked";
+    }
+
+    // Collapsible <details> log: every main-story quest plus the optional side
+    // quests, each tagged done / active / locked. Collapsed by default to keep
+    // the sidebar compact; the at-a-glance current quest stays above it.
+    function renderQuestLog() {
+        const mainRows = runtime.quests.map((quest) => {
+            const status = questStatus(quest);
+            const icon = status === "done" ? "✅" : status === "active" ? "▶" : "🔒";
+            return `<li class="ql-${status}">${icon} ${escapeHtml(quest.title)}</li>`;
+        }).join("");
+        const sideRows = SIDE_QUESTS.map((side) => {
+            const done = sideQuestDone(side.key);
+            const icon = done ? "✅" : "○";
+            return `<li class="ql-${done ? "done" : "side"}" title="${escapeHtml(side.hint)}">${icon} ${escapeHtml(side.name)}</li>`;
+        }).join("");
+        const mainDone = runtime.state.completedQuestIds.length;
+        const sideDoneCount = SIDE_QUESTS.filter((s) => sideQuestDone(s.key)).length;
+        return `<details class="quest-log">`
+            + `<summary>Quest Log — ${mainDone}/${runtime.quests.length} main · ${sideDoneCount}/${SIDE_QUESTS.length} side</summary>`
+            + `<p class="ql-group">Main Quests</p><ul class="ql-list">${mainRows}</ul>`
+            + `<p class="ql-group">Side Quests</p><ul class="ql-list">${sideRows}</ul>`
+            + `</details>`;
     }
 
     function renderQuest() {
         const quest = runtime.quests[runtime.state.currentQuestId];
         const complete = runtime.state.completedQuestIds.length;
-        dom.quest.innerHTML = quest
-            ? `<p><strong>${escapeHtml(quest.title)}</strong></p><p>${escapeHtml(quest.objective)}</p><p class="kind-dim">${complete}/${runtime.quests.length} complete • ${runtime.state.xp} XP</p>`
-            : `<p class="kind-success">All quests complete.</p><p>${runtime.state.xp} XP earned.</p>`;
+        const summary = quest
+            ? `<p><strong>${escapeHtml(quest.title)}</strong></p><p>${escapeHtml(quest.objective)}</p><p class="kind-dim quest-xp">${complete}/${runtime.quests.length} complete • ${runtime.state.xp} XP</p>`
+            : `<p class="kind-success">All quests complete.</p><p class="quest-xp">${runtime.state.xp} XP earned.</p>`;
+        dom.quest.innerHTML = summary + renderQuestLog();
     }
 
     function renderInventory() {
         const hp = Math.max(0, Math.min(100, runtime.state.hp));
         const filled = Math.round(hp / 10);
         const bar = "█".repeat(filled) + "░".repeat(10 - filled);
-        dom.inventory.innerHTML = `<p>HP <span class="${hp > 40 ? "kind-success" : "kind-error"}">${bar}</span> ${hp}/100</p><p>${runtime.state.inventory.map(escapeHtml).join(", ") || "(empty)"}</p>`;
+        const items = runtime.state.inventory || [];
+        const itemsHtml = items.length
+            ? `<ul class="inv-items">${items.map((item) => `<li>💰 ${escapeHtml(item)}</li>`).join("")}</ul>`
+            : `<p class="inv-empty kind-dim">No treasures yet — explore rooms and grab the loot.</p>`;
+        dom.inventory.innerHTML =
+            `<p class="inv-hp">HP <span class="${hp > 40 ? "kind-success" : "kind-error"}">${bar}</span> ${hp}/100</p>`
+            + `<p class="inv-heading kind-dim">Items carried (${items.length})</p>`
+            + itemsHtml;
     }
 
     function renderRoom() {
@@ -342,8 +439,58 @@
             return `${entry.type === "dir" ? "📁" : entry.type === "exec" ? "⚡" : "📄"} ${escapeHtml(entry.name)}${marker}`;
         }).join("<br>");
         // Vignette sits under the room name (before the scrollable entry list)
-        // so the ambient mascot stays visible even when contents are long.
-        dom.room.innerHTML = `<p><strong>${escapeHtml(meta.title || runtime.state.cwd)}</strong></p><p class="kind-dim">${escapeHtml(runtime.state.cwd)}</p>${roomVignetteHtml()}<p>${entries || "(empty)"}</p>`;
+        // so the ambient mascot stays visible even when contents are long. The
+        // "In this room" label distinguishes room contents from carried items.
+        dom.room.innerHTML = `<p><strong>${escapeHtml(meta.title || runtime.state.cwd)}</strong></p><p class="kind-dim">${escapeHtml(runtime.state.cwd)}</p>${roomVignetteHtml()}<p class="room-contents-label kind-dim">In this room</p><p>${entries || "(empty)"}</p>`;
+    }
+
+    // ── Generative dungeon map ───────────────────────────────────────────────
+    // A fog-of-war tree built live from the runtime filesystem. Only rooms the
+    // player has entered (visited) and the visible doors leading off them
+    // (their direct dir-children) are drawn, so the map grows organically as the
+    // player explores and never reveals undiscovered or still-hidden areas.
+    function mapJoin(parent, name) {
+        return (parent === "/" ? "" : parent) + "/" + name;
+    }
+
+    function dirChildren(path) {
+        if (!runtime.isDir(path)) return [];
+        return runtime.entries(path, false)
+            .filter((entry) => entry.type === "dir")
+            .map((entry) => mapJoin(path, entry.name));
+    }
+
+    function mapNodeLabel(path, visited) {
+        const name = runtime.basename(path) || path.replace(/^\//, "");
+        const isHere = path === runtime.state.cwd;
+        const cls = isHere ? "map-here" : visited.has(path) ? "map-seen" : "map-fog";
+        const marker = isHere ? " ←" : "";
+        return `<span class="${cls}">${escapeHtml(name)}/</span>${marker}`;
+    }
+
+    function mapBuild(path, prefix, visited, discovered, out) {
+        const kids = dirChildren(path).filter((child) => discovered.has(child));
+        kids.forEach((child, i) => {
+            const last = i === kids.length - 1;
+            out.push(prefix + (last ? "└── " : "├── ") + mapNodeLabel(child, visited));
+            mapBuild(child, prefix + (last ? "    " : "│   "), visited, discovered, out);
+        });
+    }
+
+    function renderMap() {
+        if (!dom.map) return;
+        const root = (runtime.world && runtime.world.root) || "/entrance";
+        const visited = new Set(runtime.state.visited || []);
+        visited.add(runtime.state.cwd);
+        const discovered = new Set([root]);
+        for (const node of visited) {
+            discovered.add(node);
+            for (const child of dirChildren(node)) discovered.add(child);
+        }
+        const out = [mapNodeLabel(root, visited)];
+        mapBuild(root, "", visited, discovered, out);
+        const legend = `<p class="map-legend kind-dim">${visited.size} room${visited.size === 1 ? "" : "s"} explored · ← you are here</p>`;
+        dom.map.innerHTML = `<pre class="map-tree" aria-label="Discovered dungeon map">${out.join("\n")}</pre>${legend}`;
     }
 
     function renderPrompt() {

--- a/web/assets/js/runtime.js
+++ b/web/assets/js/runtime.js
@@ -44,6 +44,21 @@
         return String(text).split("\n");
     }
 
+    // Local-day helpers for the Daily Challenge (browser Date is fine here).
+    function isoDay(d) {
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, "0");
+        const day = String(d.getDate()).padStart(2, "0");
+        return `${y}-${m}-${day}`;
+    }
+    function todayStr() { return isoDay(new Date()); }
+    function yesterdayStr() { return isoDay(new Date(Date.now() - 86400000)); }
+    function dailyGoalFor(dateStr) {
+        let h = 0;
+        for (const c of dateStr) h += c.charCodeAt(0);
+        return 30 + (h % 4) * 10; // 30 / 40 / 50 / 60
+    }
+
     // ── Encounter Creature Gallery ──────────────────────────────────────
     // Monospace-safe ASCII portraits keyed by encounter SCRIPT BASENAME
     // (runScript receives cmd.slice(2)). Pure ASCII only — no variation-
@@ -58,7 +73,26 @@
         goblet:   ["        \\        /", "         \\.----./", "          \\    /", "           \\  /", "            )(", "           /  \\", "          /____\\", "      a jeweled goblet stands"].join("\n"),
         spell:    ["          *  .  +", "        .  _||_  .", "      +   /    \\   *", "     .   | rune |   .", "      *   \\____/   +", "        '  |  |  '", "     ~ the glyph ignites ~"].join("\n"),
         crystal:  ["         _________", "        /  _   _  \\", "       |  (o) (o)  |", "       |     >     |", "       |   \\___/   |", "        \\_________/", "      the crystal murmurs..."].join("\n"),
+        penguin:  ["        .--.", "       /o  o\\", "       \\ <> /", "      /|    |\\", "     ` |    | `", "       |____|", "       /    \\", "    a dapper penguin"].join("\n"),
+        nyarlathotep: ["      .-~~~-.", "     / .   . \\", "    |  (o o)  |", "     \\  \\_/  /", "    .-/.   .\\-.", "    ) (|   |) (", "     ~~ \\___/ ~~", "    the crawling chaos"].join("\n"),
+        fountain: ["       .  .  .", "        \\ | /", "       .-=^=-.", "      (   :   )", "       \\ ~~~ /", "        |___|", "       /_____\\", "    a wishing fountain"].join("\n"),
     };
+
+    // Bestiary metadata (display name + blurb) for each catalogued encounter,
+    // in the order shown by the `bestiary` command.
+    const BESTIARY = [
+        { key: "treasure", name: "Treasure Chest", blurb: "Spills jewels for the bold." },
+        { key: "monster", name: "Coiled Serpent", blurb: "Strikes at the unprepared." },
+        { key: "ghost", name: "Restless Ghost", blurb: "Drifts through locked doors." },
+        { key: "potion", name: "Glowing Potion", blurb: "Restores a weary hero's vigor." },
+        { key: "statue", name: "Stone Guardian", blurb: "Wakes when you draw near." },
+        { key: "goblet", name: "Jeweled Goblet", blurb: "A prize of the deep vaults." },
+        { key: "spell", name: "Igniting Rune", blurb: "Crackles with raw magick." },
+        { key: "crystal", name: "Murmuring Crystal", blurb: "Whispers half-truths." },
+        { key: "penguin", name: "Dapper Penguin", blurb: "Inexplicably formal." },
+        { key: "nyarlathotep", name: "The Crawling Chaos", blurb: "Best left uncatalogued." },
+        { key: "fountain", name: "Wishing Fountain", blurb: "Bubbles with possibility." },
+    ];
 
     // Return the {kind:'art'} portrait for a script basename, or null. O(1), pure.
     function encounterArtLine(script) {
@@ -189,6 +223,22 @@
         { min: 130, title: "Terminal Master" },
         { min: 190, title: "Archmage of the Command Line" },
     ];
+    // Achievements catalog. Icons use only emoji verified to render in COLOR in
+    // the monospace log. test(s) reads runtime state; unlocked once, +5 XP each.
+    const ACHIEVEMENTS = [
+        { id: "first_steps", icon: "🧭", title: "First Steps", desc: "Found your place with pwd.", test: (s) => (s.stats.commands.pwd || 0) > 0 },
+        { id: "cartographer", icon: "✨", title: "Cartographer", desc: "Charted the dungeon with map or tree.", test: (s) => (s.stats.commands.map || 0) > 0 || (s.stats.commands.tree || 0) > 0 },
+        { id: "scholar", icon: "💡", title: "Scholar", desc: "Read three ancient scrolls.", test: (s) => (s.stats.catScrollCount || 0) >= 3 },
+        { id: "world_builder", icon: "⚡", title: "World-Builder", desc: "Conjured a room with mkdir.", test: (s) => (s.stats.commands.mkdir || 0) > 0 },
+        { id: "treasure_hunter", icon: "💰", title: "Treasure Hunter", desc: "Claimed your first loot.", test: (s) => (s.inventory || []).length > 0 },
+        { id: "key_master", icon: "🔓", title: "Key-Master", desc: "Unlocked a hidden room.", test: (s) => Object.keys(s.reveals || {}).length > 0 },
+        { id: "arena_graduate", icon: "🏅", title: "Arena Graduate", desc: "Cleared a Training Arena run.", test: (s) => !!(s.flags && s.flags.arena_cleared) },
+        { id: "speed_demon", icon: "🏆", title: "Speed Demon", desc: "Finished a timed Speed Run.", test: (s) => s.speedrunBest != null },
+        { id: "trailblazer", icon: "✅", title: "Trailblazer", desc: "Completed a Path-Finder journey.", test: (s) => !!(s.flags && s.flags.pathfind_done) },
+        { id: "naturalist", icon: "✨", title: "Naturalist", desc: "Catalogued 5 creatures in the bestiary.", test: (s) => (s.bestiary || []).length >= 5 },
+        { id: "seasoned", icon: "🔥", title: "Seasoned Adventurer", desc: "Earned 150 XP.", test: (s) => (s.xp || 0) >= 150 },
+    ];
+
     // Compass rose for the Path-Finder mini-game (box-safe ASCII).
     const PATHFIND_ART = [
         "       .  N  .",
@@ -196,6 +246,19 @@
         "   W ----(+)---- E",
         "    '   / | \\   '",
         "       '  S  '",
+    ].join("\n");
+    // Banner shown when the player's rank advances (box-safe ASCII).
+    const LEVELUP_ART = [
+        "    .  *  .       *   .    *  .",
+        "   *   L E V E L   U P !   *",
+        "    *  .   *       .   *  .  *",
+    ].join("\n");
+    // Header for the profile / character sheet (box-safe ASCII).
+    const PROFILE_ART = [
+        "  .-----------------------------.",
+        "  |      C H A R A C T E R      |",
+        "  |          S H E E T          |",
+        "  '-----------------------------'",
     ].join("\n");
 
     function defaultState(root) {
@@ -209,6 +272,7 @@
             userNodes: {},
             completedQuestIds: [],
             currentQuestId: 0,
+            visited: [],
             history: [],
             historyIndex: -1,
             flags: {},
@@ -216,6 +280,10 @@
             trainer: null,
             pathfind: null,
             speedrunBest: null,
+            achievements: [],
+            bestiary: [],
+            daily: { date: null, baselineXp: 0, goal: 0, completed: false, streak: 0, lastDate: null },
+            rankIndex: 0,
             stats: { commands: {}, catScrollCount: 0, initialized: false },
         };
     }
@@ -283,14 +351,50 @@
                 pathfind: this.cmdPathfind,
                 seek: this.cmdPathfind,
                 journey: this.cmdPathfind,
+                achievements: this.cmdAchievements,
+                badges: this.cmdAchievements,
+                profile: this.cmdProfile,
+                stats: this.cmdProfile,
+                sheet: this.cmdProfile,
+                bestiary: this.cmdBestiary,
+                codex: this.cmdBestiary,
+                daily: this.cmdDaily,
+                challenge: this.cmdDaily,
+                commands: this.cmdCommands,
+                cmds: this.cmdCommands,
+                menu: this.cmdCommands,
+                features: this.cmdCommands,
             };
         }
 
         execute(line) {
+            this.refreshDaily();
             // While the Training Arena is active, every line is an answer, not a command.
-            if (this.state.trainer && this.state.trainer.active) {
-                return this.trainerInput(line);
+            const out = (this.state.trainer && this.state.trainer.active)
+                ? this.trainerInput(line)
+                : this.runPipeline(line);
+            // Achievements first (they award XP), then daily, then rank-up (reads final XP).
+            const extra = this.checkAchievements().concat(this.checkDaily()).concat(this.checkRankUp());
+            return extra.length ? out.concat(extra) : out;
+        }
+
+        // Celebrate when accumulated XP crosses an ARENA_RANKS threshold.
+        checkRankUp() {
+            const idx = ARENA_RANKS.reduce((acc, r, i) => ((this.state.xp || 0) >= r.min ? i : acc), 0);
+            if (typeof this.state.rankIndex !== "number") {
+                this.state.rankIndex = idx; // baseline for older saves; no retroactive party
+                return [];
             }
+            if (idx <= this.state.rankIndex) return [];
+            this.state.rankIndex = idx;
+            return [
+                { kind: "control", action: "levelup" },
+                { kind: "art", text: LEVELUP_ART },
+                { kind: "success", text: `★  You are now ${ARENA_RANKS[idx].title}!` },
+            ];
+        }
+
+        runPipeline(line) {
             const segments = splitPipes(line.trim());
             if (!segments.length) return [];
             let stdin = null;
@@ -456,6 +560,8 @@
                 { kind: "info", text: "Open the Docs panel with F1 (or click Docs)." },
                 { kind: "dim", text: "Try:  pwd | ls -F | cat scroll | cd cellar | tree | map | hint | cowsay hi | ./oracle" },
                 { kind: "magic", text: "Mini-games:  'train' drills spells (or 'speedrun' against the clock);  'pathfind' quests to a target room. All grant XP." },
+                { kind: "dim", text: "Type 'achievements' for badges, 'profile' for your sheet, 'bestiary' to catalogue encounters, or 'daily' for today's challenge." },
+                { kind: "info", text: "New here? Type 'commands' for the full command deck of web-exclusive features." },
             ];
         }
 
@@ -511,11 +617,201 @@
             this.state.xp += xp;
             const title = pf.targetTitle;
             this.state.pathfind = null;
+            this.state.flags.pathfind_done = true;
             const flair = moves <= 1 ? "  A direct route!" : moves <= 3 ? "  Swiftly done." : "";
             return [
                 { kind: "success", text: `🧭 You reached ${title} in ${moves} move${moves === 1 ? "" : "s"}!  +${xp} XP${flair}` },
                 { kind: "dim", text: "Type 'pathfind' to seek a new destination." },
             ];
+        }
+
+        // ── Achievements ─────────────────────────────────────────────────────
+        // Evaluate the catalog against current state; award any newly-earned
+        // badge (once each, +5 XP) and return announcement lines.
+        checkAchievements() {
+            if (!Array.isArray(this.state.achievements)) this.state.achievements = [];
+            const have = this.state.achievements;
+            const out = [];
+            for (const a of ACHIEVEMENTS) {
+                if (have.includes(a.id)) continue;
+                let earned = false;
+                try { earned = !!a.test(this.state); } catch (e) { earned = false; }
+                if (!earned) continue;
+                have.push(a.id);
+                this.state.xp += 5;
+                out.push({ kind: "success", text: `${a.icon} Achievement unlocked: ${a.title} — ${a.desc}  (+5 XP)` });
+            }
+            return out;
+        }
+
+        // Character sheet: a one-glance summary of all progress.
+        cmdProfile() {
+            const s = this.state;
+            const rank = (ARENA_RANKS.filter((r) => (s.xp || 0) >= r.min).pop() || ARENA_RANKS[0]).title;
+            const cmds = s.stats.commands || {};
+            const distinct = Object.keys(cmds).length;
+            const total = Object.values(cmds).reduce((a, b) => a + b, 0);
+            const inv = s.inventory || [];
+            const best = s.speedrunBest != null ? `${s.speedrunBest.toFixed(1)}s` : "—";
+            const label = (text) => `  ${(text + ":").padEnd(18)}`;
+            return [
+                { kind: "art", text: PROFILE_ART },
+                { kind: "magic", text: `  Rank:  ${rank}` },
+                { kind: "output", text: `${label("XP")}${s.xp}        HP: ${s.hp}/100` },
+                { kind: "output", text: `${label("Quests")}${s.completedQuestIds.length}/${this.quests.length} complete` },
+                { kind: "output", text: `${label("Badges")}${(s.achievements || []).length}/${ACHIEVEMENTS.length} earned` },
+                { kind: "output", text: `${label("Scrolls read")}${s.stats.catScrollCount || 0}` },
+                { kind: "output", text: `${label("Commands")}${distinct} distinct (${total} cast)` },
+                { kind: "output", text: `${label("Hidden rooms")}${Object.keys(s.reveals || {}).length} unlocked` },
+                { kind: "output", text: `${label("Best speed run")}${best}` },
+                { kind: "output", text: `${label("Inventory")}${inv.length ? inv.join(", ") : "(empty)"}` },
+                { kind: "dim", text: "  'achievements' for badges  ·  'train' / 'speedrun' / 'pathfind' to grow" },
+            ];
+        }
+
+        // ── Daily Challenge ──────────────────────────────────────────────────
+        // Each local day offers an XP goal; completing it on consecutive days
+        // builds a streak. Rolls over automatically on the first command of a
+        // new day. Date use is fine in the browser.
+        refreshDaily() {
+            if (!this.state.daily) {
+                this.state.daily = { date: null, baselineXp: 0, goal: 0, completed: false, streak: 0, lastDate: null };
+            }
+            const d = this.state.daily;
+            const today = todayStr();
+            if (d.date === today) return;
+            // New day: reset the day's progress (streak is judged on completion).
+            d.date = today;
+            d.baselineXp = this.state.xp;
+            d.goal = dailyGoalFor(today);
+            d.completed = false;
+        }
+
+        checkDaily() {
+            const d = this.state.daily;
+            if (!d || d.completed || !d.date) return [];
+            const earned = this.state.xp - d.baselineXp;
+            if (earned < d.goal) return [];
+            d.completed = true;
+            d.streak = (d.lastDate === yesterdayStr()) ? d.streak + 1 : 1;
+            d.lastDate = d.date;
+            this.state.xp += 25;
+            return [
+                { kind: "success", text: `🔥 Daily challenge complete!  +25 XP  ·  Streak: ${d.streak} day${d.streak === 1 ? "" : "s"}` },
+                { kind: "dim", text: "Come back tomorrow to keep the streak alive." },
+            ];
+        }
+
+        cmdDaily() {
+            this.refreshDaily();
+            const d = this.state.daily;
+            const earned = Math.max(0, this.state.xp - d.baselineXp);
+            return [
+                { kind: "magic", text: `✨ Daily Challenge — ${d.date}` },
+                { kind: "output", text: `   Goal:     earn ${d.goal} XP today` },
+                { kind: "output", text: `   Progress: ${d.completed ? "✅ complete" : `${Math.min(earned, d.goal)}/${d.goal} XP`}` },
+                { kind: "output", text: `   Streak:   ${d.streak} day${d.streak === 1 ? "" : "s"}` },
+                { kind: "dim", text: d.completed ? "   Done! Return tomorrow to extend your streak." : "   Earn XP via train / speedrun / pathfind / encounters / badges." },
+            ];
+        }
+
+        // Bestiary: catalogue of encounters you've run. `bestiary <key>` shows
+        // the art + blurb for a discovered creature; bare `bestiary` lists all.
+        cmdBestiary(args) {
+            const seen = this.state.bestiary || [];
+            const want = (args[0] || "").toLowerCase();
+            if (want) {
+                const entry = BESTIARY.find((e) => e.key === want);
+                if (!entry) return [{ kind: "error", text: `No such creature: ${want}` }];
+                if (!seen.includes(want)) return [{ kind: "dim", text: `You haven't encountered the ${entry.name} yet.` }];
+                return [
+                    { kind: "art", text: ENCOUNTER_ART[want] || "" },
+                    { kind: "magic", text: `  ${entry.name}` },
+                    { kind: "output", text: `  ${entry.blurb}` },
+                ];
+            }
+            const lines = [{ kind: "magic", text: `✨ Bestiary — ${seen.length}/${BESTIARY.length} catalogued` }];
+            for (const e of BESTIARY) {
+                lines.push(seen.includes(e.key)
+                    ? { kind: "success", text: `  ✅ ${e.name} — ${e.blurb}` }
+                    : { kind: "dim", text: "  🔒 ??? — undiscovered" });
+            }
+            lines.push({ kind: "dim", text: "  Run an encounter (e.g. ./treasure) to catalogue it.  'bestiary <name>' to view one." });
+            return lines;
+        }
+
+        cmdAchievements() {
+            const have = this.state.achievements || [];
+            const lines = [{ kind: "magic", text: `🏅 Achievements — ${have.length}/${ACHIEVEMENTS.length} unlocked` }];
+            for (const a of ACHIEVEMENTS) {
+                const got = have.includes(a.id);
+                lines.push({
+                    kind: got ? "success" : "dim",
+                    text: got ? `${a.icon} ${a.title} — ${a.desc}` : `🔒 ${a.title} — ${a.desc}`,
+                });
+            }
+            return lines;
+        }
+
+        // ── Command reference ────────────────────────────────────────────────
+        // Discoverability hub for the web-only features. These commands have no
+        // bash equivalent and are otherwise invisible, so surface them grouped
+        // by purpose with a one-line "what it does" and live progress counts.
+        cmdCommands() {
+            const s = this.state;
+            const badges = (s.achievements || []).length;
+            const seen = (s.bestiary || []).length;
+            const rank = (ARENA_RANKS.filter((r) => (s.xp || 0) >= r.min).pop() || ARENA_RANKS[0]).title;
+            const groups = [
+                {
+                    title: "🎮 Mini-games (earn XP)",
+                    items: [
+                        ["train", "Drill spells from memory in the Training Arena"],
+                        ["speedrun", "Same trials, against the clock — beat your best time"],
+                        ["pathfind", "Navigate to a target room in the fewest cd moves"],
+                    ],
+                },
+                {
+                    title: "📊 Progress & collection",
+                    items: [
+                        ["profile", `Your character sheet — ${rank}, XP, stats`],
+                        ["achievements", `Badge catalogue — ${badges}/${ACHIEVEMENTS.length} unlocked`],
+                        ["bestiary", `Creature codex — ${seen}/${BESTIARY.length} catalogued`],
+                        ["daily", "Today's challenge and your streak"],
+                    ],
+                },
+                {
+                    title: "🧭 Navigation & lore",
+                    items: [
+                        ["map", "ASCII map of the dungeon"],
+                        ["look", "Describe the current room and its contents"],
+                        ["hint", "A nudge toward the next objective"],
+                        ["quest", "Your active quest objectives"],
+                    ],
+                },
+                {
+                    title: "✨ Flavour",
+                    items: [
+                        ["cowsay <text>", "An ASCII cow speaks"],
+                        ["fortune", "A random adage"],
+                        ["banner <text>", "Big block letters"],
+                        ["sl", "Watch a train roll by"],
+                    ],
+                },
+            ];
+            const lines = [
+                { kind: "banner", text: "BASHCRAWL — COMMAND DECK" },
+                { kind: "dim", text: "Web-exclusive commands beyond the core POSIX toolkit. Type any name to run it." },
+            ];
+            for (const g of groups) {
+                lines.push({ kind: "magic", text: g.title });
+                for (const [name, desc] of g.items) {
+                    const pad = name.padEnd(16, " ");
+                    lines.push({ kind: "output", text: `  ${pad}${desc}` });
+                }
+            }
+            lines.push({ kind: "dim", text: "Core commands (ls, cd, cat, grep, find, tree...) work too — see Docs (F1)." });
+            return lines;
         }
 
         promptLabel() {
@@ -614,6 +910,7 @@
             const answered = t.pos;
             const rank = ARENA_RANKS.filter((r) => t.score >= r.min).pop() || ARENA_RANKS[0];
             const completed = answered >= t.queue.length;
+            if (completed) this.state.flags.arena_cleared = true;
             this.state.trainer = null;
             const lines = [];
             if (quit) lines.push({ kind: "dim", text: "You lower your blade and step out of the arena." });
@@ -1077,7 +1374,11 @@
             if (!encounter) return [{ kind: "error", text: `No runnable script: ./${script}` }];
             const messages = [{ kind: "magic", text: `${encounter.icon || "⚡"} ${encounter.description || script}` }];
             const portrait = encounterArtLine(script);
-            if (portrait) messages.unshift(portrait);
+            if (portrait) {
+                messages.unshift(portrait);
+                if (!Array.isArray(this.state.bestiary)) this.state.bestiary = [];
+                if (!this.state.bestiary.includes(script)) this.state.bestiary.push(script);
+            }
             for (const item of encounter.grants_items || []) {
                 if (!this.state.inventory.includes(item)) this.state.inventory.push(item);
             }

--- a/web/index.html
+++ b/web/index.html
@@ -62,6 +62,14 @@
                     <h2>Location</h2>
                     <div id="room-panel"></div>
                 </section>
+                <!-- Generative dungeon map: a fog-of-war tree that grows as the
+                     player explores. Built live from the runtime filesystem in
+                     renderMap() (game.js); only visited rooms and their visible
+                     doors are drawn, so it never spoils undiscovered areas. -->
+                <section class="tui-panel map-panel">
+                    <h2>Map</h2>
+                    <div id="map-panel"></div>
+                </section>
             </aside>
 
             <section class="tui-content">


### PR DESCRIPTION
Follow-up to #58 (merged). PR #58's squash shipped the web work through the Path-Finder / Speed-Run mini-games. While the loop kept building, **8 completed and tested features landed after that merge cutoff** and were not included. This PR brings them into `main`.

Pure front-end change — **4 files, +657/−10**, no generated-data churn (`web/data` is byte-identical to main).

## What's included
| Feature | Command(s) | What it adds |
|---|---|---|
| 🏅 Achievements | `achievements` / `badges` | 11-badge catalogue, +5 XP each |
| 🧾 Profile | `profile` / `stats` | character sheet (rank, XP, quests, badges, hidden rooms, best speed-run) |
| 📖 Bestiary | `bestiary` / `codex` | creature codex with reveal-on-encounter ASCII art |
| 🔥 Daily Challenge | `daily` | per-day XP goal + consecutive-day streak |
| ✨ Level-up flash | _(automatic)_ | gold screen flash on rank-up |
| 💥 Damage flash | _(automatic)_ | red radial edge-pulse on HP loss |
| 🎮 Commands deck | `commands` / `menu` | discoverability hub for all web-exclusive commands, with live progress counts |
| 🗺️ Sidebar overhaul | _(UI)_ | generative fog-of-war **Map** that grows as you explore; **Inventory** split into HP vitals + a clear carried-items list; collapsible **Quest Log** (main + side quests) |

## Notes
- All animation is gated behind `prefers-reduced-motion: no-preference`.
- In-log glyphs limited to the monospace-safe set; UI chrome can use any emoji.
- Verified live in the browser; `make web-test` → `"ok": true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)