### PR TITLE
fix(web): remove phantom scriptorium/observatory rooms; make map generative

### DIFF
--- a/web/assets/js/game.js
+++ b/web/assets/js/game.js
@@ -93,7 +93,7 @@
         if (p.includes("/.vault") || p.includes("/vault")) return "vault";
         if (p.includes("/graveyard") || p.includes("/.chapel") || p.includes("/chapel")) return "graveyard";
         if (p.includes("/cellar") || p.includes("/armoury") || p.includes("/chamber")) return "cellar";
-        if (p === "/entrance" || p.endsWith("/entrance") || p.includes("/workshop") || p.includes("/scriptorium")) return "entrance";
+        if (p === "/entrance" || p.endsWith("/entrance") || p.includes("/workshop")) return "entrance";
         return "deep";
     }
 
@@ -119,7 +119,7 @@
     ].join("\n");
     append("banner", BANNER);
     append("info", "Welcome to Bashcrawl Web.");
-    append("dim", "Try: pwd, ls -F, cat scroll, cd cellar  •  cd scriptorium then sort verses | uniq  •  hint, map, tree, cowsay hi  •  F1/Ctrl+/ for Docs.");
+    append("dim", "Try: pwd, ls -F, cat scroll, cd cellar  •  cat scroll | wc -l  •  hint, map, tree, cowsay hi  •  F1/Ctrl+/ for Docs.");
     append("magic", "🆕 Mini-games:  train  (drill commands)  ·  speedrun  (timed, beat your best)  ·  pathfind  (quest to a room). All earn XP.");
     if (runtime.state.trainer && runtime.state.trainer.active) {
         for (const out of runtime.trainerChallenge()) append(out.kind, out.text);

--- a/web/assets/js/runtime.js
+++ b/web/assets/js/runtime.js
@@ -121,14 +121,6 @@
             "        |||||",
             "        |||||",
         ].join("\n"),
-        portal: [
-            "          .  *  .   *  .   .",
-            "        ╭───────────────────╮",
-            "        │  ◌  the portal  ◌  │",
-            "        │   ───→  /scriptorium",
-            "        ╰───────────────────╯",
-            "          *  .   .  *  .  *",
-        ].join("\n"),
         treasure: [
             "       _.--\"\"--._",
             "      / _      _ \\",
@@ -454,7 +446,7 @@
         cmdHelp() {
             return [
                 { kind: "info", text: "Open the Docs panel with F1 (or click Docs)." },
-                { kind: "dim", text: "Try:  pwd | ls -F | cat scroll | cd cellar | tree | map | hint | cowsay hi | ./oracle" },
+                { kind: "dim", text: "Try:  pwd | ls -F | cat scroll | cd cellar | tree | map | hint | cowsay hi | ./treasure" },
                 { kind: "magic", text: "Mini-games:  'train' drills spells (or 'speedrun' against the clock);  'pathfind' quests to a target room. All grant XP." },
             ];
         }
@@ -860,21 +852,32 @@
             return [{ kind: "output", text: lines.join("\n") }];
         }
 
+        // Draw the dungeon map by walking the live runtime filesystem, so the map
+        // never advertises a room you cannot actually `cd` into. Only directories
+        // (rooms) are shown; revealed hidden rooms appear un-dotted via entries().
         cmdMap() {
             const here = this.state.cwd;
-            const arrow = (path) => path === here ? " ← you are here" : "";
-            const lines = [
-                "  /entrance" + arrow("/entrance"),
-                "  ├── cellar/" + arrow("/entrance/cellar"),
-                "  │   └── armoury/" + arrow("/entrance/cellar/armoury"),
-                "  │       ├── chamber/" + arrow("/entrance/cellar/armoury/chamber"),
-                "  │       └── workshop/" + arrow("/entrance/cellar/armoury/workshop"),
-                "  ├── scriptorium/" + arrow("/entrance/scriptorium"),
-                "  │   └── observatory/" + arrow("/entrance/scriptorium/observatory"),
-                "  └── .chapel/  (hidden — try ls -la)",
-                "      └── courtyard/aviary/hall/library/.study/" + arrow("/entrance/.chapel/courtyard/aviary/hall/library/.study"),
-            ];
-            return [{ kind: "art", text: lines.join("\n") }];
+            const root = this.world.root || "/entrance";
+            const marker = (path) => (path === here ? "  ← you are here" : "");
+            const lines = [root + marker(root)];
+            const walk = (path, prefix, depth) => {
+                if (depth > 4) return;
+                const rooms = this.entries(path, false).filter((entry) => entry.type === "dir");
+                rooms.forEach((entry, idx) => {
+                    const last = idx === rooms.length - 1;
+                    const tee = last ? "└── " : "├── ";
+                    const childPath = `${path === "/" ? "" : path}/${entry.name}`;
+                    lines.push(prefix + tee + entry.name + "/" + marker(childPath));
+                    walk(childPath, prefix + (last ? "    " : "│   "), depth + 1);
+                });
+            };
+            walk(root, "  ", 0);
+            const out = [{ kind: "art", text: lines.join("\n") }];
+            // Teach that the dungeon hides more than it shows, until it doesn't.
+            if (this.entries(root, true).some((entry) => entry.type === "dir" && entry.hidden)) {
+                out.push({ kind: "dim", text: "Some passages stay hidden until unlocked — try `ls -la` and read the scrolls." });
+            }
+            return out;
         }
 
         cmdLook() {
@@ -891,7 +894,7 @@
 
         cmdHint() {
             const q = this.quests[this.state.currentQuestId];
-            if (!q) return [{ kind: "success", text: "No quests left. Try `map`, `tree`, `cowsay hi`, or `./oracle` in /entrance/scriptorium." }];
+            if (!q) return [{ kind: "success", text: "No quests left. Try `map`, `tree`, `cowsay hi`, or the `train` / `speedrun` / `pathfind` mini-games." }];
             return [{ kind: "magic", text: `🔮 ${q.title}\n   ${q.hint || q.objective}` }];
         }
 


### PR DESCRIPTION
## Problem

The static web bundle advertised an `/entrance/scriptorium` room — complete with an `./oracle` encounter and an `observatory/` sub-room — that exists **nowhere** in the bash game or the exported `web/data`. Players told to `cd scriptorium` hit `Not a directory: /entrance/scriptorium`, and the in-game `map` command drew these phantom rooms on every render.

`find entrance -iname "*scriptorium*"` returns nothing; `oracle`, `verses`, and `observatory` appear nowhere on disk or in the exported data.

## Key finding

The "Scriptorium" **is** a real game concept — but it is the **help system**, not a room under `entrance/`. Deep in the dungeon (`.chapel/courtyard/aviary/hall/library/.study/`), running `./grimoire` creates a `portal` symlink → `src/help/`, and `cd portal` reaches "the Scriptorium" (the source of the help system). The "Scriptorium Key" quest reward refers to this. **That lore is left fully intact** — only the contradictory, hand-authored web-JS references to a fictional `/entrance/scriptorium` room are removed. (The many "Observatory" hits elsewhere in the repo are the unrelated Flask log-viewer app, not rooms.)

## Approach: Option (a) + generative map

Adding a real `entrance/scriptorium/` (option b) would directly contradict the established grimoire→portal Scriptorium and require invasive changes to the bash game, the content registries, and a world-data re-export. Instead this PR removes the phantom references so the web only advertises rooms that exist, and makes the map **generative** so it can never drift again.

## Changes (`web/assets/js/` only — no data changes)

- **`game.js`** — drop `/scriptorium` from the room-vignette mapping; replace the broken `cd scriptorium then sort verses | uniq` welcome hint with a real working pipe, `cat scroll | wc -l`.
- **`runtime.js`** — rewrite `cmdMap()` to walk the **live runtime filesystem** (the same `world.directories` source `cd` reads), so the map can never again advertise an unreachable room. It also surfaces a hidden-passage hint while rooms remain locked, and disappears once all are unlocked.
- **`runtime.js`** — fix `cmdHelp` (`./oracle` → `./treasure`) and `cmdHint` (drop the `./oracle in /entrance/scriptorium` fallback); remove the dead, unused `ART.portal` block whose art pointed at `/scriptorium`.

The only remaining "Scriptorium" mention is in `cmdSource` ("Scriptorium quest ready" after sourcing the grimoire), which is lore-accurate and refers to the help-system Scriptorium, not a navigable room.

## Validation

- `make web-test` → `"ok": true`, `error_count: 0`, and **zero data churn** (only the two JS files changed; `web/data/*.json` rebuilt byte-identical).
- Node harness driving the real runtime against `web/data`:
  - `cd scriptorium` / `cd observatory` → consistent `Not a directory` errors
  - `map` lists only real, reachable rooms (`/entrance → cellar → armoury → {chamber, workshop}`) with the "you are here" marker tracking the current room
  - `cat scroll | wc -l` (the new welcome suggestion) works at `/entrance`

Because `cmdMap()` and `cmdCd()` now read the same `world.directories`, the map and navigation are consistent by construction.

https://claude.ai/code/session_01B24JQLCN1xYerdAapiA1Yh

---
_Generated by [Claude Code](https://claude.ai/code/session_01B24JQLCN1xYerdAapiA1Yh)_