### PR TITLE
chore: adopt standardization baseline

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,46 @@
+name: Claude
+
+# @claude mention handler, seeded from bamr87/bamr87 templates/agent-context/.
+# Mention @claude in an issue or PR comment and Claude Code picks up the task.
+#
+# Auth (house convention): CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`)
+# preferred; ANTHROPIC_API_KEY used only when the OAuth token is absent.
+# See bamr87/bamr87 docs/AI-INTEGRATION.md.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+permissions:
+  contents: read
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}


### PR DESCRIPTION
Automated by bamr87 standardize-fanout (tools/fanout.sh): seeds the baseline artifacts (editorconfig,ci,agent-context,claude). Additive-only — nothing the repo already has is overwritten. See bamr87/bamr87 docs/STANDARDS.md.