### PR TITLE
ci: reduce Actions waste — make Blank-Slate Audit's silent no-op visible, align checkout@v7

### DIFF
--- a/.github/workflows/blank-slate-audit.yml
+++ b/.github/workflows/blank-slate-audit.yml
@@ -7,7 +7,8 @@ name: Blank-Slate Audit
 #
 # Prerequisite (one-time, by a maintainer): run `claude setup-token` locally and
 # add the result as the repository secret CLAUDE_CODE_OAUTH_TOKEN. Without it the
-# job is a graceful no-op (scripts/playtest.sh skips).
+# preflight job emits a warning and the audit job is visibly SKIPPED in the run
+# list (no toolchain installs, no fake green "audit").
 
 on:
   schedule:
@@ -40,8 +41,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  preflight:
+    name: Check playtest credentials
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      has_token: ${{ steps.check.outputs.has_token }}
+    steps:
+      - name: Check CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has_token=false" >> "$GITHUB_OUTPUT"
+          msg="CLAUDE_CODE_OAUTH_TOKEN secret is not set — no playtest ran and the self-teaching gate did not gate."
+          msg="$msg Fix: a maintainer runs 'claude setup-token' locally and adds the result as that repository secret."
+          echo "::warning title=Blank-Slate Audit skipped::$msg"
+          cat >> "$GITHUB_STEP_SUMMARY" <<'SUMMARY'
+          ## Blank-Slate Audit — SKIPPED (no credentials)
+
+          The `CLAUDE_CODE_OAUTH_TOKEN` repository secret is not set, so **no playtest ran**
+          and the self-teaching gate did not gate anything.
+
+          **Fix (one-time, by a maintainer):** run `claude setup-token` locally and add the
+          result as the `CLAUDE_CODE_OAUTH_TOKEN` repository secret.
+          SUMMARY
+
   audit:
     name: Blank-slate playthrough
+    needs: preflight
+    if: needs.preflight.outputs.has_token == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
       id-token: write
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
Implements the audited CI-waste plan for `bamr87/bashcrawl` (8 workflows: consolidate:3, disable_dead:1, fix_failure:1, keep:3). Every plan claim was re-verified against the live YAML and the Actions run history before changing anything.

## What changed (2 files)

### 1. `blank-slate-audit.yml` — fix_failure: stop the fake-green no-op (the one live defect)

**Verified evidence:** 4/4 weekly cron runs "succeeded" (06-22, 06-29, 07-06, 07-13) — but `gh api .../runs/<id>/jobs` for the 2026-07-13 run shows the **`Run blank-slate playtest + gate` step executed in 0 seconds** (`06:02:45 -> 06:02:45`), after ~20s of installing Python deps + Node + the Claude Code CLI. `gh secret list` confirms the repo has **no secrets at all** — `CLAUDE_CODE_OAUTH_TOKEN` was never provisioned, so `scripts/playtest.sh` exit-0 no-ops. The self-teaching gate has never actually gated.

**Fix:** a `preflight` job now checks the secret before anything else:

- **Token present** → `audit` job runs exactly as before (its steps are byte-identical; all triggers — weekly cron + `workflow_dispatch` with all 4 inputs — preserved).
- **Token missing** → a `::warning::` annotation + a step summary explain exactly what didn't run and the one-time fix; the `audit` job shows as **skipped** in the run list; the three toolchain install steps never execute (saves the wasted setup every Monday).

**Maintainer action still required (cannot be done from a PR):** run `claude setup-token` locally and add the result as the `CLAUDE_CODE_OAUTH_TOKEN` repository secret. Until then, Mondays will show a visible skip + warning instead of a fake green audit.

### 2. `claude.yml` — keep, consistency nit from the plan: `actions/checkout@v4` → `@v7`

Verified that today's dependabot bump (#67) was v6→v7 only, so it missed this file (seeded at v4 by the standardization baseline #73). Aligning now avoids a future dependabot major-bump PR (each of which triggers a CI + Claude run pair).

## Verified as already done / correct — no changes (6 workflows)

| Workflow | Plan verdict | Verification |
|---|---|---|
| `ci.yml` | keep | All 6 window failures occurred 2026-07-06 18:14–18:45 (pre-redesign, broken by the v3.1.0 refactor); since the "5 workflows → 3" merge at 19:42 it is 11/11 green through 07-16 (incl. the same dependabot PRs re-running green). Already has `concurrency: ci-${{ github.ref }}` + cancel-in-progress, per-job timeouts (10/20/10), pip cache. |
| `pages.yml` | keep | Green at ~30–40s; `concurrency: pages`, `timeout-minutes: 10` on both jobs, pip cache, tight `paths:` filters confirmed in YAML — it correctly did not fire on the docs/standardization pushes. |
| `claude.yml` | keep | 3 lifetime runs, all `skipped` (dependabot comments hit `issue_comment`; the job-level `@claude` guard short-circuits). Skipped runs bill zero minutes; the guard cannot move to trigger level. |
| `dependency-update.yml` | disable_dead | Already deleted by `7dee2a0` ("ci: redesign CI/CD — 5 workflows → 3", 2026-07-06) after 0/2 lifetime cron success; Dependabot Updates covers it (10/10 green). |
| `test-framework.yml` | consolidate | Already deleted (`fdc9329`, v3.1.0); pytest suite folded into `ci.yml`'s `test` job (`make validate-contracts` + `make test`). |
| `code-quality.yml` | consolidate | Already deleted (`fdc9329`); linting folded into `ci.yml`'s `lint` job (`scripts/lint.sh`: shellcheck/yamllint/markdownlint/ruff). |
| `game-tests.yml` | consolidate | Already deleted (`7dee2a0`); content rules moved to `scripts/validate_content_contracts.py`, run by `ci.yml`'s contracts step. |

**Retire candidates:** none in this plan.

## Lint

`actionlint` (with embedded shellcheck of run blocks): clean across the whole `.github/workflows/` tree. `yamllint -c .yamllint.yml` on both touched files: clean (claude.yml's pre-existing line-29 length warning is untouched and warning-level only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
