### PR TITLE
TermForge TUI HUD: one shared presenter rendering in terminal and web

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ make test-mcp          # playtest-harness smoke tests in a local .venv
 make playtest          # blank-slate agent playtest (needs claude CLI + OAuth token)
 make lint              # shellcheck + yamllint + markdownlint + ruff
 make lint-js           # node --check over every tracked JS file
-make tty-demo          # play bashcrawl in this terminal (JS emulator on node)
+make tty-demo          # play bashcrawl in this terminal (full-screen HUD; ARGS="--no-hud" for the classic stream)
 make telnet-demo       # serve bashcrawl at telnet://127.0.0.1:2323 (ARGS="--raw" for nc)
 make agentwatch        # AI-agent task dashboard (ARGS="--data-dir logs/sessions" for real logs)
 make clean             # bash lib/reset.sh — reset game state
@@ -87,11 +87,12 @@ Hidden areas (all rooted under `entrance/`) are unlocked by collecting treasures
 | `lib/` | Minimal shared shell libs: `colors.sh`, `log.sh` (JSONL), `yaml_reader.sh`, `reset.sh`. |
 | `setup.sh` | chmods encounter scripts (`--quick` for tooling/tests). |
 | `termforge/core/` | The TermForge kernel (source of truth): `parser`, `vfs` (+ read-only providers), `shell` (hook spine, injectable clock/rng), `packs/{posix,flavour}`, `protocol`, `view`, `sinks/{dom,ansi}`, `input`. Dual-mode files, vendored to `web/assets/js/vendor/termforge/`. |
-| `termforge/node/` | Node hosts: `host-tty.js`, `host-telnet.js` + `telnet-codec.js` (RFC 854 subset), `index.js` (framework namespace for require()). |
+| `termforge/node/` | Node hosts: `host-tty.js` (full-screen HUD via the `session.hud()` contract, or classic stream with `--no-hud`/piped stdio), `tui.js` (TuiScreen: app-agnostic ANSI compositor — sidebar panels, toast row, input row), `host-telnet.js` + `telnet-codec.js` (RFC 854 subset), `index.js` (framework namespace for require()). |
 | `termforge/apps/` | `bashcrawl.js` (the game as an App descriptor for the hosts), `procwatch/` (custom-tool reference: live metrics as provider files), `agentwatch/` (AI-agent task dashboard: TaskSource → board/feed + live files; JSONL adapter for `logs/sessions/`). |
 | `termforge/test/` | `node --test` suites incl. golden transcripts (pixel-identity contract; regenerate only via `record-goldens.js --update`) and the telnet loopback integration. |
 | `web/assets/js/runtime.js` | The **bashcrawl game assembly** over TermForge: `class Runtime extends TermForge.Shell`, the full 74-entry `this.handlers` literal (the `validate_runtime_commands.py` regex contract — one `key: ref,` per line, bare references only), and `installGameHooks()` (quests/achievements/daily/trainer/pathfind/encounters). |
-| `web/assets/js/game.js` | Story mode: quests, XP, map, hero, effects (log via the shared TerminalView). |
+| `web/assets/js/hud.js` | The **shared HUD presenter** (one engine, two renderers): side quests, fog-of-war map model, HP/XP bars, room/quest/hero models, and `diffEvents()` — consumed by both `game.js` (DOM) and the TTY host (`tui.js` panels). Loaded like runtime.js: classic script in the browser, require()'d by `termforge/apps/bashcrawl.js`. |
+| `web/assets/js/game.js` | Story mode DOM renderer over `BashcrawlHud` models + CSS effects (log via the shared TerminalView). |
 | `web/assets/js/arcade.js` | Practice Arcade framework + the 4 mini-games (scoped bare Runtime per game). |
 | `web/assets/js/reference.js` | Cheatsheet library, concept spotlight, inline syntax hints. |
 | `web/assets/js/shell.js` | Mode router (Story·Arcade·Reference), landing overlay, XP bridge, toasts. |
@@ -137,7 +138,7 @@ mv ../../.chapel ../../chapel   # Unlock a hidden room (target may be 2+ levels 
 
 ### Web JS
 - Framework-free app code, IIFE modules, classic scripts. Load order: the 13 vendored
-TermForge core files (`protocol → parser → state → vfs → hooks → registry → shell → packs/posix → packs/flavour → view → sinks/dom → sinks/ansi → input`), then `storage → runtime → docs → reference → arcade → game → shell`. `validate_static_web.py` enforces that every vendor file loads before `runtime.js`. New features plug into `shell.js` (mode router) or an arcade game descriptor.
+TermForge core files (`protocol → parser → state → vfs → hooks → registry → shell → packs/posix → packs/flavour → view → sinks/dom → sinks/ansi → input`), then `storage → runtime → hud → docs → reference → arcade → game → shell`. `validate_static_web.py` enforces that every vendor file loads before `runtime.js`. New features plug into `shell.js` (mode router) or an arcade game descriptor.
 - A mini-game = *(seed world + goal predicate + scoring)* over a scoped bare `Runtime` —
   never reimplement command behavior outside `termforge/core/` + `runtime.js`.
 - Framework changes go in `termforge/core/` (then `make web-build` re-vendors); game-only

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ web-preview: web-build ## Preview the web app at http://127.0.0.1:8000
 # ── TermForge hosts (the same game/tools, off the browser) ─────────────
 
 .PHONY: tty-demo
-tty-demo: web-build ## Play bashcrawl in this terminal (JS emulator on node)
-	@$(NODE) termforge/node/host-tty.js --app bashcrawl
+tty-demo: web-build ## Play bashcrawl in this terminal (JS emulator on node; ARGS="--no-hud" for the classic stream)
+	@$(NODE) termforge/node/host-tty.js --app bashcrawl $(ARGS)
 
 .PHONY: telnet-demo
 telnet-demo: web-build ## Serve bashcrawl at telnet://127.0.0.1:2323 (ARGS="--raw" for nc)

--- a/docs/termforge/architecture.md
+++ b/docs/termforge/architecture.md
@@ -26,7 +26,8 @@ termforge/
     index.js            the framework namespace for require()
     data-loader.js      reads web/data/*.json from disk
     cli.js              argv parsing + app resolution
-    host-tty.js         local terminal host (raw mode or piped line mode)
+    host-tty.js         local terminal host (full-screen HUD, raw mode, or piped line mode)
+    tui.js              TuiScreen: full-screen ANSI compositor (sidebar panels, toast row, input row)
     telnet-codec.js     RFC 854 subset state machine (socket-free)
     host-telnet.js      multi-session telnet/TCP server
   apps/

--- a/docs/termforge/authoring-apps.md
+++ b/docs/termforge/authoring-apps.md
@@ -16,6 +16,7 @@ module.exports = {
                     runtime,            // duck type below
                     banner: [ { kind: "banner", text: "MY TOOL" } ],   // Line[] printed once
                     onControl(action) { /* "reset": rebuild session.runtime */ },
+                    hud() { /* optional: graphical frame, see below */ },
                 };
                 return session;
             },
@@ -25,6 +26,23 @@ module.exports = {
 ```
 
 `runtime` is anything with the Shell surface the hosts use: `execute(line) -> Line[]`, `completions(text) -> string[]`, `promptLabel() -> string`, and `state` (with `history`/`historyIndex` for the editor). A plain `TermForge.Shell` qualifies; so does the bashcrawl `Runtime` subclass.
+
+## The hud() contract (optional)
+
+An app that wants the full-screen treatment implements `session.hud()`. Panel-capable hosts (the TTY host's `TuiScreen`, `termforge/node/tui.js`) call it once at boot and again after every executed line:
+
+```js
+hud() {
+    return {
+        panels: [ { title: "⚙ STATUS", lines: [ { kind: "info", text: "…" } ] } ],
+        strip:  [ { kind: "info", text: "one-line HUD for narrow terminals" } ],
+        events: [ { type: "xp", text: "+25 XP" } ],   // toast queue since last call
+        prompt: runtime.promptLabel(),
+    };
+}
+```
+
+Everything is pre-formatted data — `{kind,text}` lines reuse the AnsiSink palette, so the sidebar matches the log colors. `events` is stateful: the session diffs its own snapshots so hosts never track app state (types `quest`/`damage`/`xp`/`item`/`levelup` map to toast styles). Sessions without `hud()` — and any session under `--no-hud` or piped stdio — run in the classic line-stream mode. Bashcrawl's implementation delegates to the shared presenter `web/assets/js/hud.js`, the same models its browser sidebar renders — one engine, two renderers.
 
 Run it: `node termforge/node/host-tty.js --app ./my-tool.js` or `node termforge/node/host-telnet.js --app ./my-tool.js --raw`.
 

--- a/scripts/validate_static_web.py
+++ b/scripts/validate_static_web.py
@@ -34,6 +34,7 @@ def validate() -> dict:
         "assets/css/terminal.css",
         "assets/js/storage.js",
         "assets/js/runtime.js",
+        "assets/js/hud.js",
         "assets/js/docs.js",
         "assets/js/reference.js",
         "assets/js/arcade.js",

--- a/termforge/apps/bashcrawl.js
+++ b/termforge/apps/bashcrawl.js
@@ -5,19 +5,27 @@
 //
 //   createApp({ dataDir? }) -> {
 //       id, name,
-//       createSession({ width? }) -> { runtime, banner, onControl }
+//       createSession({ width? }) -> { runtime, banner, onControl, hud }
 //   }
+//
+// hud() is the optional graphical contract: hosts that can draw panels (the
+// TTY host's TuiScreen) call it after every command and get the same models
+// the web sidebar renders — panels, a narrow-terminal strip, and the semantic
+// events (quest/damage/xp/item/levelup) that drive effects on both surfaces.
 
 const path = require("node:path");
 const { loadWebData } = require("../node/data-loader.js");
 
-// runtime.js is a classic script: it reads global.TermForge at load time and
-// attaches global.BashcrawlRuntime. Publish the framework namespace, then
-// let require() execute it once.
+// runtime.js and hud.js are classic scripts: they read global.TermForge /
+// global.BashcrawlRuntime at load or call time and attach their own globals.
+// Publish the framework namespace, then let require() execute each once.
 function loadGameRuntime() {
     if (!globalThis.BashcrawlRuntime) {
         globalThis.TermForge = globalThis.TermForge || require("../node/index.js");
         require(path.resolve(__dirname, "..", "..", "web", "assets", "js", "runtime.js"));
+    }
+    if (!globalThis.BashcrawlHud) {
+        require(path.resolve(__dirname, "..", "..", "web", "assets", "js", "hud.js"));
     }
     return globalThis.BashcrawlRuntime;
 }
@@ -25,16 +33,19 @@ function loadGameRuntime() {
 function createApp(options = {}) {
     const data = loadWebData(options.dataDir);
     const BashcrawlRuntime = loadGameRuntime();
+    const Hud = globalThis.BashcrawlHud;
 
     return {
         id: "bashcrawl",
         name: "Bashcrawl",
 
         createSession() {
+            let prevSnap = null;
+            const runtime = new BashcrawlRuntime.Runtime(data);
             const session = {
-                runtime: new BashcrawlRuntime.Runtime(data),
+                runtime,
                 banner: [
-                    { kind: "banner", text: "BASHCRAWL" },
+                    { kind: "banner", text: runtime.uiText.bannerArt },
                     { kind: "info", text: "Welcome to Bashcrawl on the TermForge terminal." },
                     { kind: "dim", text: "Try: pwd, ls -F, cat scroll, cd cellar  •  cat scroll | wc -l  •  hint, map, tree, cowsay hi." },
                     { kind: "dim", text: "Mini-games: train · speedrun · pathfind. Ctrl+D (or 'exit' in raw mode) leaves the dungeon." },
@@ -45,7 +56,24 @@ function createApp(options = {}) {
                 onControl(action) {
                     if (action === "reset") {
                         session.runtime = new BashcrawlRuntime.Runtime(data);
+                        prevSnap = null;
                     }
+                },
+                // Graphical HUD frame for panel-capable hosts. Stateful: each
+                // call diffs against the previous snapshot so the host gets
+                // ready-to-toast events without tracking game state itself.
+                hud() {
+                    const runtime = session.runtime;
+                    Hud.ensureVisited(runtime);
+                    const snap = Hud.snapshot(runtime);
+                    const events = prevSnap ? Hud.diffEvents(prevSnap, snap) : [];
+                    prevSnap = snap;
+                    return {
+                        panels: Hud.panels(runtime),
+                        strip: Hud.strip(runtime),
+                        events,
+                        prompt: runtime.promptLabel(),
+                    };
                 },
             };
             return session;

--- a/termforge/node/host-tty.js
+++ b/termforge/node/host-tty.js
@@ -3,25 +3,46 @@
 // TermForge TTY host — run a TermForge app in the local terminal.
 //
 //   node termforge/node/host-tty.js [--app bashcrawl|procwatch|<module.js>]
-//                                   [--no-color] [--data-dir DIR]
+//                                   [--no-color] [--no-hud] [--data-dir DIR]
 //
 // Interactive TTY: raw mode with the framework LineEditor (echo, history via
-// arrows, Tab completion, ^C cancels the line, ^D exits). Piped stdin runs in
-// line mode and echoes each command after the prompt, so scripted transcripts
-// read like a session.
+// arrows, Tab completion, ^C cancels the line, ^D exits). When the app
+// implements the hud() contract (see termforge/apps/bashcrawl.js) the session
+// runs full-screen: a TuiScreen frame with sidebar panels, a toast row for
+// game events, and a live input row — the terminal twin of the web sidebar.
+// --no-hud (or a non-TTY stdio) falls back to the classic line stream; piped
+// stdin runs in line mode and echoes each command after the prompt, so
+// scripted transcripts read like a session.
 
 const TermForge = require("./index.js");
 const { parseArgs, resolveApp } = require("./cli.js");
+const { TuiScreen } = require("./tui.js");
+
+const TOAST_KINDS = { quest: "magic", damage: "error", xp: "success", item: "art", levelup: "magic" };
+const TOAST_MS = 2200;
 
 function main() {
     const opts = parseArgs(process.argv.slice(2), {
         app: "bashcrawl",
         color: true,
+        hud: true,
         dataDir: "",
     });
     const app = resolveApp(opts.app, opts.dataDir ? { dataDir: opts.dataDir } : {});
     const session = app.createSession({ width: process.stdout.columns || 80 });
+    const interactive = process.stdin.isTTY && process.stdout.isTTY;
+    const hudActive = Boolean(opts.hud && interactive && typeof session.hud === "function");
 
+    if (hudActive) {
+        runHudMode(session, opts);
+    } else {
+        runStreamMode(session, opts, interactive);
+    }
+}
+
+// ── Classic line-stream mode (piped stdin, --no-hud, HUD-less apps) ─────────
+
+function runStreamMode(session, opts, interactive) {
     const sink = new TermForge.sinks.AnsiSink({
         write: (chunk) => process.stdout.write(chunk),
         color: opts.color && Boolean(process.stdout.isTTY),
@@ -37,26 +58,14 @@ function main() {
     });
 
     const runLine = (line) => {
-        const state = session.runtime.state;
-        if (line.trim()) {
-            if (!state.history.length || state.history[state.history.length - 1] !== line) {
-                state.history.push(line);
-            }
-            state.historyIndex = state.history.length;
-        }
-        let outputs;
-        try {
-            outputs = session.runtime.execute(line);
-        } catch (err) {
-            outputs = [{ kind: "error", text: `termforge: internal error: ${err.message}` }];
-        }
-        view.appendOutputs(outputs);
+        pushHistory(session.runtime.state, line);
+        view.appendOutputs(executeLine(session, line));
     };
 
     view.appendOutputs(session.banner || []);
 
     let editor = null;
-    if (process.stdin.isTTY && process.stdout.isTTY) {
+    if (interactive) {
         editor = new TermForge.input.LineEditor({
             promptLabel: () => session.runtime.promptLabel(),
             completions: (text) => session.runtime.completions(text),
@@ -86,6 +95,145 @@ function main() {
             runLine(line);
         });
         rl.on("close", () => process.exit(0));
+    }
+}
+
+// ── Full-screen HUD mode ────────────────────────────────────────────────────
+
+function runHudMode(session, opts) {
+    const screen = new TuiScreen({
+        write: (chunk) => process.stdout.write(chunk),
+        color: opts.color,
+    });
+
+    // The log pane is still a TerminalView — same buffer semantics and control
+    // routing as every other surface; only the sink changes.
+    const view = new TermForge.view.TerminalView({
+        sink: {
+            write: (lines) => screen.appendLog(lines),
+            clear: () => screen.clearLog(),
+        },
+        cap: 2000,
+        onControl(action) {
+            session.onControl(action);
+            if (action === "reset") {
+                editor.state = session.runtime.state;
+                refreshHud();
+            }
+            return action === "reset";
+        },
+    });
+
+    // Toasts show one at a time; hud() events queue up behind each other.
+    const toasts = [];
+    let toastTimer = null;
+    const nextToast = () => {
+        const line = toasts.shift() || null;
+        screen.setToast(line);
+        screen.render();
+        if (toastTimer) clearTimeout(toastTimer);
+        toastTimer = line ? setTimeout(nextToast, TOAST_MS) : null;
+        if (toastTimer && toastTimer.unref) toastTimer.unref();
+    };
+    const pushToasts = (events) => {
+        for (const ev of events || []) {
+            toasts.push({ kind: TOAST_KINDS[ev.type] || "info", text: ev.text });
+        }
+        if (!toastTimer && toasts.length) nextToast();
+    };
+
+    const refreshHud = () => {
+        const frame = session.hud();
+        screen.setPanels(frame.panels);
+        screen.setStrip(frame.strip);
+        screen.setPrompt(frame.prompt);
+        pushToasts(frame.events);
+    };
+
+    const runLine = (line) => {
+        pushHistory(session.runtime.state, line);
+        view.appendLine("dim", `${session.runtime.promptLabel()} ${line}`);
+        view.appendOutputs(executeLine(session, line));
+        refreshHud();
+        screen.setInput("");
+        screen.render();
+    };
+
+    const editor = new TermForge.input.LineEditor({
+        promptLabel: () => session.runtime.promptLabel(),
+        completions: (text) => session.runtime.completions(text),
+        state: session.runtime.state,
+        echo: false,
+        // The frame owns all painting. LineEditor writes are decoded instead of
+        // streamed: the Tab-completion candidate list (the one thing the editor
+        // says that isn't already in our state) lands in the log; every other
+        // chunk (prompt echoes, redraws) is superseded by the frame repaint.
+        write: (chunk) => {
+            const text = String(chunk);
+            if (text.startsWith("\r\n") && text.trim()) {
+                for (const row of text.trim().split("\r\n")) view.appendLine("info", row);
+                screen.render();
+            }
+        },
+        onSubmit(line) {
+            runLine(line);
+            editor.state = session.runtime.state;
+        },
+        onEof() {
+            teardown();
+            process.stdout.write("Farewell, adventurer.\n");
+            process.exit(0);
+        },
+    });
+
+    const teardown = () => {
+        if (toastTimer) clearTimeout(toastTimer);
+        screen.stop();
+        if (process.stdin.isTTY) process.stdin.setRawMode(false);
+    };
+    process.on("exit", () => { if (screen.started) screen.stop(); });
+
+    const feed = TermForge.input.createByteDecoder((ev) => {
+        if (ev.type === "interrupt") view.appendLine("dim", "^C");
+        editor.feed(ev);
+        if (ev.type === "submit") return; // onSubmit repainted the full frame
+        if (ev.type === "interrupt" || ev.type === "clearScreen") {
+            screen.setInput(editor.buffer);
+            screen.render();
+            return;
+        }
+        screen.setInput(editor.buffer);
+        screen.renderInput();
+    });
+
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.on("data", (buf) => feed(buf.toString("utf8")));
+    process.stdout.on("resize", () => {
+        screen.resize(process.stdout.columns || 80, process.stdout.rows || 24);
+        screen.render();
+    });
+
+    view.appendOutputs(session.banner || []);
+    refreshHud();
+    screen.start({ cols: process.stdout.columns || 80, rows: process.stdout.rows || 24 });
+}
+
+// ── shared helpers ──────────────────────────────────────────────────────────
+
+function pushHistory(state, line) {
+    if (!line.trim()) return;
+    if (!state.history.length || state.history[state.history.length - 1] !== line) {
+        state.history.push(line);
+    }
+    state.historyIndex = state.history.length;
+}
+
+function executeLine(session, line) {
+    try {
+        return session.runtime.execute(line);
+    } catch (err) {
+        return [{ kind: "error", text: `termforge: internal error: ${err.message}` }];
     }
 }
 

--- a/termforge/node/tui.js
+++ b/termforge/node/tui.js
@@ -1,0 +1,267 @@
+"use strict";
+// TermForge TUI compositor — a full-screen ANSI frame for byte-stream hosts.
+//
+// Draws the graphical session layout the web app gets from its DOM panels:
+//
+//   ┌ log (scrollback, wrapped) ─────────────┬─ sidebar panels ─┐
+//   │ …                                      │ ─ ⚔ TITLE ────── │
+//   │ …                                      │   pre-formatted  │
+//   │ …                                      │   {kind,text}    │
+//   ├─ toast row (transient event) ──────────┴──────────────────┤
+//   └ input row (prompt + line buffer, live cursor) ────────────┘
+//
+// Narrow terminals collapse the sidebar into a one-line status strip above
+// the log. The compositor is app-agnostic: panel/strip/toast content arrives
+// as data (the app's hud() contract, see termforge/apps/bashcrawl.js); kinds
+// reuse the AnsiSink SGR palette so the sidebar matches the log colors.
+// No timers and no clock in here — hosts own toast lifetimes and repaints.
+
+const { ANSI_STYLES } = require("../core/sinks/ansi.js");
+
+const ESC = "\u001b";
+const CSI = `${ESC}[`;
+const MIN_WIDE = 88;    // need this many columns before the sidebar pays rent
+const SIDEBAR_W = 30;
+const MIN_ROWS = 8;     // below this: log + input only, no chrome
+
+// Approximate display width: CJK, Hangul, and emoji cells count 2; combining
+// marks, ZWJ, and variation selectors count 0. Close enough for panel layout
+// (each row is erased before repaint, so a rare miss never leaves artifacts).
+function charWidth(ch) {
+    const code = ch.codePointAt(0);
+    if (code === 0x200d || code === 0xfe0f || (code >= 0x0300 && code <= 0x036f)) return 0;
+    if ((code >= 0x1100 && code <= 0x115f)
+        || (code >= 0x2e80 && code <= 0xa4cf)
+        || (code >= 0xac00 && code <= 0xd7a3)
+        || (code >= 0xf900 && code <= 0xfaff)
+        || (code >= 0xfe30 && code <= 0xfe4f)
+        || (code >= 0xff00 && code <= 0xff60)
+        || (code >= 0xffe0 && code <= 0xffe6)
+        || (code >= 0x1f000 && code <= 0x1faff)
+        || (code >= 0x2600 && code <= 0x27bf)
+        || (code >= 0x2b00 && code <= 0x2bff)) return 2;
+    return 1;
+}
+
+function dispWidth(text) {
+    let width = 0;
+    for (const ch of String(text)) width += charWidth(ch);
+    return width;
+}
+
+/** Clip text to a display width (never mid-codepoint; wide cells respected). */
+function clip(text, width) {
+    let out = "";
+    let used = 0;
+    for (const ch of String(text)) {
+        const w = charWidth(ch);
+        if (used + w > width) break;
+        out += ch;
+        used += w;
+    }
+    return out;
+}
+
+/** Soft-wrap one logical line into display rows of at most `width` cells. */
+function wrap(text, width) {
+    const str = String(text);
+    if (!str) return [""];
+    const rows = [];
+    let row = "";
+    let used = 0;
+    for (const ch of str) {
+        const w = charWidth(ch);
+        if (used + w > width) {
+            rows.push(row);
+            row = "";
+            used = 0;
+        }
+        row += ch;
+        used += w;
+    }
+    rows.push(row);
+    return rows;
+}
+
+class TuiScreen {
+    /**
+     * @param {object} options
+     * @param {(chunk: string) => void} options.write  receives ANSI frames
+     * @param {boolean} [options.color]   emit SGR codes (default true)
+     * @param {number}  [options.logCap]  scrollback cap in logical lines
+     */
+    constructor(options) {
+        const opts = options || {};
+        if (typeof opts.write !== "function") throw new Error("TuiScreen requires options.write");
+        this._write = opts.write;
+        this.color = opts.color !== false;
+        this.logCap = opts.logCap || 500;
+        this.cols = 80;
+        this.rows = 24;
+        this.log = [];
+        this.panels = null;
+        this.strip = null;
+        this.toastLine = null;
+        this.prompt = "$";
+        this.input = "";
+        this.started = false;
+    }
+
+    // ── state feeds ─────────────────────────────────────────────────────────
+
+    setPanels(panels) { this.panels = Array.isArray(panels) && panels.length ? panels : null; }
+
+    setStrip(lines) { this.strip = Array.isArray(lines) && lines.length ? lines : null; }
+
+    setPrompt(label) { this.prompt = String(label || "$"); }
+
+    setInput(buffer) { this.input = String(buffer || ""); }
+
+    setToast(line) { this.toastLine = line || null; }
+
+    appendLog(lines) {
+        for (const line of lines || []) {
+            this.log.push({ kind: line.kind || "output", text: line.text || "" });
+        }
+        if (this.log.length > this.logCap) {
+            this.log.splice(0, this.log.length - this.logCap);
+        }
+    }
+
+    clearLog() { this.log.length = 0; }
+
+    // ── lifecycle ───────────────────────────────────────────────────────────
+
+    start(size) {
+        this.started = true;
+        if (size) { this.cols = size.cols || 80; this.rows = size.rows || 24; }
+        this._write(`${CSI}?1049h${CSI}2J${CSI}H`);
+        this.render();
+    }
+
+    stop() {
+        if (!this.started) return;
+        this.started = false;
+        this._write(`${CSI}?1049l${CSI}?25h`);
+    }
+
+    resize(cols, rows) {
+        this.cols = cols || this.cols;
+        this.rows = rows || this.rows;
+        if (this.started) this._write(`${CSI}2J`);
+    }
+
+    // ── painting ────────────────────────────────────────────────────────────
+
+    _sgr(code, text) {
+        if (!this.color || !code) return text;
+        return `${CSI}${code}m${text}${CSI}0m`;
+    }
+
+    _kind(kind, text) {
+        return this._sgr(ANSI_STYLES[kind || "output"] || "", text);
+    }
+
+    _wide() {
+        return Boolean(this.panels) && this.cols >= MIN_WIDE && this.rows >= MIN_ROWS;
+    }
+
+    // Flatten panels into sidebar rows: a rule-with-title header per panel,
+    // then its body lines, truncated to the row budget with a dim ellipsis.
+    _sidebarRows(budget) {
+        const rows = [];
+        for (const panel of this.panels || []) {
+            const title = ` ${panel.title} `;
+            const rule = "─".repeat(Math.max(0, SIDEBAR_W - dispWidth(title) - 1));
+            rows.push(this._sgr("2", "─") + this._sgr("1;36", title) + this._sgr("2", rule));
+            for (const line of panel.lines || []) {
+                rows.push(" " + this._kind(line.kind, clip(line.text, SIDEBAR_W - 1)));
+            }
+        }
+        if (rows.length > budget && budget > 0) {
+            rows.length = budget - 1;
+            rows.push(this._sgr("2", " …"));
+        }
+        return rows;
+    }
+
+    // Wrap the log tail into at most `budget` display rows of `width` cells.
+    _logRows(budget, width) {
+        const rows = [];
+        for (let i = this.log.length - 1; i >= 0 && rows.length < budget; i -= 1) {
+            const entry = this.log[i];
+            const wrapped = wrap(entry.text, width);
+            for (let j = wrapped.length - 1; j >= 0 && rows.length < budget; j -= 1) {
+                rows.push(this._kind(entry.kind, wrapped[j]));
+            }
+        }
+        return rows.reverse();
+    }
+
+    _inputCol() {
+        return Math.min(this.cols, dispWidth(this.prompt) + 1 + dispWidth(this.input) + 1);
+    }
+
+    /** Fast path: repaint only the input row (per-keystroke). */
+    renderInput() {
+        if (!this.started) return;
+        const row = this.rows;
+        const text = clip(`${this.prompt} ${this.input}`, this.cols - 1);
+        this._write(`${CSI}${row};1H${CSI}2K${text}${CSI}${row};${this._inputCol()}H`);
+    }
+
+    /** Full frame repaint. */
+    render() {
+        if (!this.started) return;
+        const parts = [`${CSI}?25l`];
+        const put = (row, text) => parts.push(`${CSI}${row};1H${CSI}2K${text}`);
+        const wide = this._wide();
+        const chrome = this.rows >= MIN_ROWS;
+        const toastRow = chrome ? this.rows - 1 : 0;
+        let logTop = 1;
+
+        if (!wide && chrome && this.strip) {
+            for (const line of this.strip) {
+                put(logTop, this._kind(line.kind, clip(line.text, this.cols)));
+                logTop += 1;
+            }
+            put(logTop, this._sgr("2", "─".repeat(this.cols)));
+            logTop += 1;
+        }
+
+        const logBottom = (chrome ? toastRow : this.rows) - 1;
+        const budget = Math.max(0, logBottom - logTop + 1);
+        const sepCol = wide ? this.cols - SIDEBAR_W - 1 : this.cols + 1;
+        const logWidth = wide ? sepCol - 2 : this.cols;
+        const logRows = this._logRows(budget, Math.max(10, logWidth));
+        const sideRows = wide ? this._sidebarRows(budget) : [];
+
+        for (let i = 0; i < budget; i += 1) {
+            const row = logTop + i;
+            let text = logRows[i] || "";
+            if (wide) {
+                // The sidebar is positioned absolutely so a stray wide glyph in
+                // the log can never push it out of its column.
+                text += `${CSI}${row};${sepCol}H` + this._sgr("2", "│") + (sideRows[i] || "");
+            }
+            put(row, text);
+        }
+
+        if (chrome) {
+            if (this.toastLine) {
+                const toast = ` ${this.toastLine.text} `;
+                const pad = Math.max(0, Math.floor((this.cols - dispWidth(toast)) / 2));
+                const style = ANSI_STYLES[this.toastLine.kind || "info"] || "36";
+                put(toastRow, " ".repeat(pad) + this._sgr(`7;${style}`, clip(toast, this.cols)));
+            } else {
+                put(toastRow, this._sgr("2", "─".repeat(this.cols)));
+            }
+        }
+
+        put(this.rows, clip(`${this.prompt} ${this.input}`, this.cols - 1));
+        parts.push(`${CSI}${this.rows};${this._inputCol()}H${CSI}?25h`);
+        this._write(parts.join(""));
+    }
+}
+
+module.exports = { TuiScreen, dispWidth, clip, wrap };

--- a/termforge/test/hud.test.js
+++ b/termforge/test/hud.test.js
@@ -1,0 +1,149 @@
+"use strict";
+// BashcrawlHud presenter contract: the shared models both renderers consume
+// (web/assets/js/game.js DOM panels, termforge/node/host-tty.js TuiScreen).
+// Loaded exactly like the browser loads it: vendored core + runtime.js +
+// hud.js as classic scripts in one sandbox realm.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const { RUNTIME_FILES, WEB_JS, loadGameData } = require("./helpers/game-harness.js");
+const { loadClassic } = require("./helpers/load-classic.js");
+
+const HUD_FILE = path.join(WEB_JS, "hud.js");
+
+function createHudRuntime() {
+    const env = loadClassic({ files: [...RUNTIME_FILES, HUD_FILE] });
+    const data = loadGameData();
+    env.sandbox.__data = data;
+    const runtime = env.run("new BashcrawlRuntime.Runtime(__data)");
+    delete env.sandbox.__data;
+    return { env, data, runtime, hud: env.sandbox.BashcrawlHud };
+}
+
+test("bar() renders clamped fill segments", () => {
+    const { hud } = createHudRuntime();
+    assert.equal(hud.bar(0, 100, 10), "░".repeat(10));
+    assert.equal(hud.bar(100, 100, 10), "█".repeat(10));
+    assert.equal(hud.bar(50, 100, 10), "█".repeat(5) + "░".repeat(5));
+    assert.equal(hud.bar(-20, 100, 10), "░".repeat(10));
+    assert.equal(hud.bar(500, 100, 10), "█".repeat(10));
+});
+
+test("snapshot + diffEvents surface xp/item/quest transitions from real play", () => {
+    const { runtime, hud } = createHudRuntime();
+    const before = hud.snapshot(runtime);
+    assert.equal(before.hp, 100);
+    assert.equal(before.inventory.length, 0);
+
+    runtime.execute("pwd"); // first-steps achievement (+XP) at minimum
+    const afterPwd = hud.snapshot(runtime);
+    assert.ok(afterPwd.xp > before.xp, "pwd should award XP");
+    const events = hud.diffEvents(before, afterPwd);
+    assert.ok(events.some((e) => e.type === "xp" && e.amount === afterPwd.xp - before.xp));
+
+    runtime.execute("cd cellar");
+    runtime.execute("./treasure");
+    const afterLoot = hud.snapshot(runtime);
+    assert.ok(afterLoot.inventory.length > afterPwd.inventory.length, "treasure should add loot");
+    const lootEvents = hud.diffEvents(afterPwd, afterLoot);
+    const item = lootEvents.find((e) => e.type === "item");
+    assert.ok(item, "expected an item event");
+    assert.ok(item.items.length >= 1);
+});
+
+test("diffEvents reports damage and levelup transitions", () => {
+    const { runtime, hud } = createHudRuntime();
+    const before = hud.snapshot(runtime);
+    runtime.state.hp -= 7;
+    const hurt = hud.snapshot(runtime);
+    const damage = hud.diffEvents(before, hurt).find((e) => e.type === "damage");
+    assert.ok(damage);
+    assert.equal(damage.amount, 7);
+
+    runtime.state.xp += 500;
+    runtime.state.rankIndex += 1;
+    const promoted = hud.snapshot(runtime);
+    const levelup = hud.diffEvents(hurt, promoted).find((e) => e.type === "levelup");
+    assert.ok(levelup, "rankIndex increase should emit a levelup event");
+    assert.ok(levelup.text.includes("★"));
+});
+
+test("questModel mirrors the quest chain and side objectives", () => {
+    const { runtime, hud } = createHudRuntime();
+    const quest = hud.questModel(runtime);
+    assert.ok(quest.mainTotal > 0);
+    assert.equal(quest.rows.length, quest.mainTotal);
+    assert.equal(quest.mainDone, 0);
+    assert.ok(quest.current && typeof quest.current.title === "string");
+    assert.equal(quest.side.length, hud.SIDE_QUESTS.length);
+    assert.ok(quest.side.every((s) => s.done === false), "no side quests done at boot");
+    assert.equal(quest.rows.filter((r) => r.status === "active").length, 1);
+});
+
+test("ensureVisited records the room trail idempotently", () => {
+    const { runtime, hud } = createHudRuntime();
+    hud.ensureVisited(runtime);
+    const first = runtime.state.visited.slice();
+    hud.ensureVisited(runtime);
+    assert.deepEqual(runtime.state.visited, first);
+    assert.ok(first.includes("/entrance"));
+});
+
+test("mapModel applies fog of war: frontier rooms appear, unvisited stay fogged", () => {
+    const { runtime, hud } = createHudRuntime();
+    hud.ensureVisited(runtime);
+    const atStart = hud.mapModel(runtime);
+    const cellar = atStart.rows.find((r) => r.name === "cellar/");
+    assert.ok(cellar, "cellar door is visible from the entrance");
+    assert.equal(cellar.seen, false, "cellar not yet visited -> fog");
+    assert.ok(!atStart.rows.some((r) => r.name === "armoury/"), "armoury undiscovered at boot");
+    assert.ok(atStart.rows.find((r) => r.here).name.includes("entrance"));
+
+    runtime.execute("cd cellar");
+    hud.ensureVisited(runtime);
+    const inCellar = hud.mapModel(runtime);
+    assert.equal(inCellar.rows.find((r) => r.name === "cellar/").here, true);
+    assert.ok(inCellar.rows.some((r) => r.name === "armoury/"), "armoury door discovered");
+    assert.ok(inCellar.explored >= 2);
+});
+
+test("roomModel and vignettes describe the current room", () => {
+    const { runtime, hud } = createHudRuntime();
+    const room = hud.roomModel(runtime);
+    assert.equal(room.path, "/entrance");
+    assert.equal(room.vignette.key, "entrance");
+    assert.ok(Array.isArray(room.vignette.art) && room.vignette.art.length > 0);
+    assert.ok(room.entries.some((e) => e.name === "scroll"));
+    const dir = room.entries.find((e) => e.type === "dir");
+    assert.ok(dir && dir.marker === "/" && dir.icon.length > 0);
+});
+
+test("panels() emits the full sidebar spec with kind/text lines", () => {
+    const { runtime, hud } = createHudRuntime();
+    hud.ensureVisited(runtime);
+    const panels = hud.panels(runtime, { width: 28 });
+    const titles = panels.map((p) => p.title);
+    for (const expected of ["HERO", "VITALS", "QUEST", "PACK", "MAP", "ROOM"]) {
+        assert.ok(titles.some((t) => t.includes(expected)), `missing panel ${expected}`);
+    }
+    for (const panel of panels) {
+        assert.ok(panel.lines.length > 0, `${panel.title} has lines`);
+        for (const line of panel.lines) {
+            assert.equal(typeof line.kind, "string");
+            assert.equal(typeof line.text, "string");
+        }
+    }
+    const vitals = panels.find((p) => p.title.includes("VITALS"));
+    assert.ok(vitals.lines[0].text.includes("HP"));
+    assert.ok(vitals.lines[0].text.includes("100/100"));
+});
+
+test("strip() compresses the HUD into one status line", () => {
+    const { runtime, hud } = createHudRuntime();
+    const strip = hud.strip(runtime);
+    assert.equal(strip.length, 1);
+    assert.ok(strip[0].text.includes("♥"));
+    assert.ok(strip[0].text.includes("/entrance"));
+});

--- a/termforge/test/tui.test.js
+++ b/termforge/test/tui.test.js
@@ -1,0 +1,128 @@
+"use strict";
+// TuiScreen compositor contract: full-screen frame layout, sidebar panels,
+// narrow-terminal strip fallback, toast row, log wrap, and input row.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { TuiScreen, dispWidth, clip, wrap } = require("../node/tui.js");
+
+const stripAnsi = (text) => text.replace(/\u001b\[[0-9;?]*[A-Za-z]/g, "");
+
+function makeScreen(options) {
+    const chunks = [];
+    const screen = new TuiScreen({ write: (chunk) => chunks.push(chunk), ...options });
+    return { screen, chunks, frame: () => stripAnsi(chunks.join("")), reset: () => { chunks.length = 0; } };
+}
+
+const PANELS = [
+    { title: "⚔ HERO", lines: [{ kind: "magic", text: "Novice Whisperer" }, { kind: "info", text: "Lv 1  ░░░░░░░░░░ 0/200" }] },
+    { title: "♥ VITALS", lines: [{ kind: "success", text: "HP ██████████ 100/100" }] },
+];
+
+test("width helpers respect wide glyphs", () => {
+    assert.equal(dispWidth("abc"), 3);
+    assert.equal(dispWidth("💰💰"), 4);
+    assert.equal(clip("💰💰💰", 4), "💰💰");
+    assert.equal(clip("abcdef", 3), "abc");
+    assert.deepEqual(wrap("abcdef", 3), ["abc", "def"]);
+    assert.deepEqual(wrap("", 5), [""]);
+});
+
+test("start/stop bracket the session in the alternate screen", () => {
+    const { screen, chunks } = makeScreen();
+    screen.start({ cols: 100, rows: 30 });
+    assert.ok(chunks.join("").includes("[?1049h"), "start enters alt screen");
+    screen.stop();
+    assert.ok(chunks.join("").includes("[?1049l"), "stop leaves alt screen");
+    assert.equal(screen.started, false);
+});
+
+test("wide layout draws sidebar panels beside the log", () => {
+    const { screen, frame, reset } = makeScreen();
+    screen.setPanels(PANELS);
+    screen.appendLog([{ kind: "info", text: "Welcome to the dungeon." }]);
+    screen.setPrompt("/entrance $");
+    screen.setInput("pwd");
+    screen.start({ cols: 100, rows: 30 });
+    reset();
+    screen.render();
+    const painted = frame();
+    assert.ok(painted.includes("⚔ HERO"), "panel title painted");
+    assert.ok(painted.includes("Novice Whisperer"), "panel body painted");
+    assert.ok(painted.includes("Welcome to the dungeon."), "log painted");
+    assert.ok(painted.includes("/entrance $ pwd"), "input row painted");
+    assert.ok(painted.includes("│"), "sidebar separator painted");
+});
+
+test("narrow layout swaps the sidebar for the status strip", () => {
+    const { screen, frame, reset } = makeScreen();
+    screen.setPanels(PANELS);
+    screen.setStrip([{ kind: "success", text: "♥ ██████████ 100 · Lv 1" }]);
+    screen.appendLog([{ kind: "output", text: "hello" }]);
+    screen.start({ cols: 60, rows: 20 });
+    reset();
+    screen.render();
+    const painted = frame();
+    assert.ok(painted.includes("♥ ██████████ 100"), "strip painted");
+    assert.ok(!painted.includes("⚔ HERO"), "sidebar suppressed under 88 cols");
+    assert.ok(painted.includes("hello"));
+});
+
+test("toast row shows transient events and clears back to a rule", () => {
+    const { screen, frame, reset } = makeScreen();
+    screen.setPanels(PANELS);
+    screen.start({ cols: 100, rows: 30 });
+    screen.setToast({ kind: "success", text: "+25 XP" });
+    reset();
+    screen.render();
+    assert.ok(frame().includes("+25 XP"), "toast painted");
+    screen.setToast(null);
+    reset();
+    screen.render();
+    assert.ok(!frame().includes("+25 XP"), "toast cleared");
+});
+
+test("log wraps long lines and respects the cap", () => {
+    const { screen, frame, reset } = makeScreen({ logCap: 5 });
+    for (let i = 0; i < 10; i += 1) {
+        screen.appendLog([{ kind: "output", text: `line-${i}` }]);
+    }
+    assert.equal(screen.log.length, 5, "cap trims the buffer");
+    screen.appendLog([{ kind: "output", text: "x".repeat(200) }]);
+    screen.start({ cols: 100, rows: 30 });
+    reset();
+    screen.render();
+    // 200 chars in a ~66-col log pane must occupy several rows, none oversized.
+    const rows = frame().split("\n").join("").length;
+    assert.ok(rows > 0);
+    assert.ok(frame().includes("x".repeat(30)), "wrapped long line painted");
+});
+
+test("tiny terminals degrade to log + input without chrome", () => {
+    const { screen, frame, reset } = makeScreen();
+    screen.setPanels(PANELS);
+    screen.setStrip([{ kind: "info", text: "strip" }]);
+    screen.appendLog([{ kind: "output", text: "deep" }]);
+    screen.start({ cols: 40, rows: 6 });
+    reset();
+    screen.setPrompt("$");
+    screen.setInput("ls");
+    screen.render();
+    const painted = frame();
+    assert.ok(painted.includes("deep"));
+    assert.ok(painted.includes("$ ls"));
+    assert.ok(!painted.includes("strip"), "no strip below MIN_ROWS");
+});
+
+test("renderInput repaints only the input row", () => {
+    const { screen, chunks, reset } = makeScreen();
+    screen.start({ cols: 100, rows: 30 });
+    screen.setPrompt("/entrance $");
+    screen.setInput("cd cel");
+    reset();
+    screen.renderInput();
+    const out = chunks.join("");
+    assert.ok(stripAnsi(out).includes("/entrance $ cd cel"));
+    assert.ok(!out.includes("[1;1H"), "no full-frame repaint");
+});

--- a/web/assets/js/game.js
+++ b/web/assets/js/game.js
@@ -25,6 +25,9 @@
     };
 
     const escapeHtml = window.TermForge.sinks.escapeHtml;
+    // The shared presenter: every panel below renders a BashcrawlHud model,
+    // the same models the terminal HUD draws (termforge/node/host-tty.js).
+    const Hud = window.BashcrawlHud;
 
     const data = await loadData();
     let runtime = new window.BashcrawlRuntime.Runtime(data, window.BashcrawlStorage.load(() => window.BashcrawlRuntime.defaultState(data.world.root)));
@@ -39,86 +42,10 @@
     });
     docsPanel.setData(data.docs, runtime);
 
-    // === Room vignettes: box-safe ASCII mascot per area (banner shimmer is pure CSS) ===
-    const ROOM_VIGNETTES = {
-        entrance: [
-            "  (  )      (  )   ",
-            "  )(   /\\   )(     ",
-            "  ||  /  \\  ||     ",
-            " _||_/    \\_||_    ",
-            "[==||      ||==]   ",
-            "   ''      ''      ",
-        ],
-        cellar: [
-            "   (~)        (~)  ",
-            "  .[ ].      .[ ]. ",
-            "  | | |      | | | ",
-            "  | | |      | | | ",
-            " _|_|_|_    _|_|_|_",
-            " '-----'    '-----'",
-        ],
-        graveyard: [
-            " .---.   __   .---.",
-            " | + |  /  \\  | R |",
-            " |   | |    | |   |",
-            " *web* |    | ~~~~ ",
-            "_|___|_|____|_|___|",
-            "  ~~~     ~~~   ~~~",
-        ],
-        vault: [
-            "      /\\          ",
-            "     /  \\   /\\    ",
-            "    / /\\ \\ /  \\   ",
-            "    \\ \\/ / \\  /   ",
-            "     \\  /   \\/    ",
-            "      \\/  *  .    ",
-        ],
-        rift: [
-            "    . * .   .  *   ",
-            "   *  .-~~~-.  .   ",
-            "  .  /  _    \\ *   ",
-            "  * |  ( o )  | .  ",
-            "   . \\  ~-~  / *   ",
-            "    * '-...-'  .   ",
-        ],
-        deep: [
-            "    *  .   *   .   ",
-            "  .   .-~~~~-.  *  ",
-            "  *  / shadow \\ .  ",
-            "   . \\        / *  ",
-            "  .   '------'  .  ",
-        ],
-    };
-
-    function vignetteKeyForRoom(actualPath, cwd) {
-        const p = String(actualPath || cwd || "");
-        if (p.includes("/.rift") || p.includes("/rift")) return "rift";
-        if (p.includes("/.vault") || p.includes("/vault")) return "vault";
-        if (p.includes("/graveyard") || p.includes("/.chapel") || p.includes("/chapel")) return "graveyard";
-        if (p.includes("/cellar") || p.includes("/armoury") || p.includes("/chamber")) return "cellar";
-        if (p === "/entrance" || p.endsWith("/entrance") || p.includes("/workshop")) return "entrance";
-        return "deep";
+    function roomVignetteHtml(vignette) {
+        const safe = vignette.art.map(escapeHtml).join("\n");
+        return `<pre class="room-vignette" data-room-art="${vignette.key}" aria-hidden="true">${safe}</pre>`;
     }
-
-    function roomVignetteHtml() {
-        const actual = (runtime.actual ? runtime.actual(runtime.state.cwd) : runtime.state.cwd);
-        const key = vignetteKeyForRoom(actual, runtime.state.cwd);
-        const art = ROOM_VIGNETTES[key] || ROOM_VIGNETTES.deep;
-        const safe = art.map(escapeHtml).join("\n");
-        return `<pre class="room-vignette" data-room-art="${key}" aria-hidden="true">${safe}</pre>`;
-    }
-
-    // Optional side objectives, grounded in real, checkable state: each hidden
-    // area is "done" once the player has revealed it (reveals map a visible path
-    // like /entrance/chapel to its dotted source). Kept separate from the main
-    // story chain so the quest log can show both tracks. Declared up here so it
-    // is initialized before the first render() during init.
-    const SIDE_QUESTS = [
-        { key: "chapel", name: "The Hidden Chapel", hint: "Search for a dotfile and unlock the chapel with grep." },
-        { key: "vault", name: "The Sealed Vault", hint: "Use variables to breach the vault." },
-        { key: "scrap", name: "The Scrapyard", hint: "Find the scrap and master symbolic links." },
-        { key: "rift", name: "The Rift", hint: "Tear open the rift for advanced trials." },
-    ];
 
     // The story log is a TermForge TerminalView painting into #output-log.
     // Control routing preserves the historical behavior: "levelup" is pure
@@ -139,18 +66,7 @@
         },
     });
     const append = (kind, text) => view.appendLine(kind, text);
-    const BANNER = [
-        "       ╔════════════════════════════════════════════════════╗",
-        "       ║   ____            __                       __      ║",
-        "       ║  / __ )___ ______/ /_  ______________ ___ / /      ║",
-        "       ║ / __  / __ `/ ___/ __ \\/ ___/ ___/ __ `__ \\/ /      ║",
-        "       ║/ /_/ / /_/ (__  ) / / / /__/ /  / / / / / / /__    ║",
-        "       ║\\____/\\__,_/____/_/ /_/\\___/_/  /_/ /_/ /_/____/    ║",
-        "       ║                                                    ║",
-        "       ║       Type  pwd  to begin the descent. F1 for help ║",
-        "       ╚════════════════════════════════════════════════════╝",
-    ].join("\n");
-    append("banner", BANNER);
+    append("banner", runtime.uiText.bannerArt);
     append("info", "Welcome to Bashcrawl Web.");
     append("dim", "Try: pwd, ls -F, cat scroll, cd cellar  •  cat scroll | wc -l  •  hint, map, tree, cowsay hi  •  F1/Ctrl+/ for Docs.");
     append("magic", "🕹  Practice Arcade (top nav or Alt+2): Path Navigator · grep/find Hunt · Pipe Puzzle · Command Flash. Reference cheatsheets: Alt+3.");
@@ -246,13 +162,7 @@
     }
 
     function snapshotState() {
-        return {
-            xp: runtime.state.xp,
-            hp: runtime.state.hp,
-            completed: runtime.state.completedQuestIds.length,
-            currentQuestId: runtime.state.currentQuestId,
-            inventory: runtime.state.inventory.slice(),
-        };
+        return Hud.snapshot(runtime);
     }
 
     function runLine(line) {
@@ -275,25 +185,28 @@
         saveAndRender();
     }
 
+    // Semantic events come from the shared presenter; this maps them onto the
+    // web's CSS effects (the terminal HUD maps the same events onto toasts).
     function triggerEffects(prev, next) {
-        if (next.completed > prev.completed) {
-            appendSparkleArt();
-            flashPanel(dom.quest);
-            applyHeroMood("quest");
-        }
-        if (next.hp < prev.hp) {
-            shakePanel(dom.inventory);
-            applyHeroMood("hurt");
-            screenFlash("damage");
-        }
-        if (next.xp > prev.xp) {
-            popXp();
-            floatXp(next.xp - prev.xp);
-            applyHeroMood("xp");
-        }
-        if (next.inventory.length > prev.inventory.length) {
-            flashPanel(dom.inventory);
-            applyHeroMood("item");
+        for (const event of Hud.diffEvents(prev, next)) {
+            if (event.type === "quest") {
+                appendSparkleArt();
+                flashPanel(dom.quest);
+                applyHeroMood("quest");
+            } else if (event.type === "damage") {
+                shakePanel(dom.inventory);
+                applyHeroMood("hurt");
+                screenFlash("damage");
+            } else if (event.type === "xp") {
+                popXp();
+                floatXp(event.amount);
+                applyHeroMood("xp");
+            } else if (event.type === "item") {
+                flashPanel(dom.inventory);
+                applyHeroMood("item");
+            }
+            // "levelup" is already celebrated via the runtime's control record
+            // (flashLevelUp in this view's onControl).
         }
     }
 
@@ -379,131 +292,66 @@
     // Record the current room (and its ancestors, so the trunk is always solid)
     // into the persisted visited-set that drives the generative map's fog of war.
     function recordVisit() {
-        const visited = runtime.state.visited || (runtime.state.visited = []);
-        const seen = new Set(visited);
-        const parts = runtime.state.cwd.split("/").filter(Boolean);
-        let acc = "";
-        for (const part of parts) {
-            acc += "/" + part;
-            if (!seen.has(acc)) { visited.push(acc); seen.add(acc); }
-        }
-    }
-
-    function sideQuestDone(key) {
-        const reveals = runtime.state.reveals || {};
-        return Object.keys(reveals).some((path) => path.endsWith("/" + key));
-    }
-
-    function questStatus(quest) {
-        if (runtime.state.completedQuestIds.includes(quest.id)) return "done";
-        if (quest.id === runtime.state.currentQuestId) return "active";
-        return "locked";
+        Hud.ensureVisited(runtime);
     }
 
     // Collapsible <details> log: every main-story quest plus the optional side
     // quests, each tagged done / active / locked. Collapsed by default to keep
     // the sidebar compact; the at-a-glance current quest stays above it.
-    function renderQuestLog() {
-        const mainRows = runtime.quests.map((quest) => {
-            const status = questStatus(quest);
-            const icon = status === "done" ? "✅" : status === "active" ? "▶" : "🔒";
-            return `<li class="ql-${status}">${icon} ${escapeHtml(quest.title)}</li>`;
-        }).join("");
-        const sideRows = SIDE_QUESTS.map((side) => {
-            const done = sideQuestDone(side.key);
-            const icon = done ? "✅" : "○";
-            return `<li class="ql-${done ? "done" : "side"}" title="${escapeHtml(side.hint)}">${icon} ${escapeHtml(side.name)}</li>`;
-        }).join("");
-        const mainDone = runtime.state.completedQuestIds.length;
-        const sideDoneCount = SIDE_QUESTS.filter((s) => sideQuestDone(s.key)).length;
+    function renderQuestLog(quest) {
+        const mainRows = quest.rows.map((row) => (
+            `<li class="ql-${row.status}">${row.icon} ${escapeHtml(row.title)}</li>`
+        )).join("");
+        const sideRows = quest.side.map((side) => (
+            `<li class="ql-${side.done ? "done" : "side"}" title="${escapeHtml(side.hint)}">${side.icon} ${escapeHtml(side.name)}</li>`
+        )).join("");
         return `<details class="quest-log">`
-            + `<summary>Quest Log — ${mainDone}/${runtime.quests.length} main · ${sideDoneCount}/${SIDE_QUESTS.length} side</summary>`
+            + `<summary>Quest Log — ${quest.mainDone}/${quest.mainTotal} main · ${quest.sideDone}/${quest.side.length} side</summary>`
             + `<p class="ql-group">Main Quests</p><ul class="ql-list">${mainRows}</ul>`
             + `<p class="ql-group">Side Quests</p><ul class="ql-list">${sideRows}</ul>`
             + `</details>`;
     }
 
     function renderQuest() {
-        const quest = runtime.quests[runtime.state.currentQuestId];
-        const complete = runtime.state.completedQuestIds.length;
-        const summary = quest
-            ? `<p><strong>${escapeHtml(quest.title)}</strong></p><p>${escapeHtml(quest.objective)}</p><p class="kind-dim quest-xp">${complete}/${runtime.quests.length} complete • ${runtime.state.xp} XP</p>`
-            : `<p class="kind-success">All quests complete.</p><p class="quest-xp">${runtime.state.xp} XP earned.</p>`;
-        dom.quest.innerHTML = summary + renderQuestLog();
+        const quest = Hud.questModel(runtime);
+        const summary = quest.current
+            ? `<p><strong>${escapeHtml(quest.current.title)}</strong></p><p>${escapeHtml(quest.current.objective)}</p><p class="kind-dim quest-xp">${quest.mainDone}/${quest.mainTotal} complete • ${quest.xp} XP</p>`
+            : `<p class="kind-success">All quests complete.</p><p class="quest-xp">${quest.xp} XP earned.</p>`;
+        dom.quest.innerHTML = summary + renderQuestLog(quest);
     }
 
     function renderInventory() {
-        const hp = Math.max(0, Math.min(100, runtime.state.hp));
-        const filled = Math.round(hp / 10);
-        const bar = "█".repeat(filled) + "░".repeat(10 - filled);
-        const items = runtime.state.inventory || [];
-        const itemsHtml = items.length
-            ? `<ul class="inv-items">${items.map((item) => `<li>💰 ${escapeHtml(item)}</li>`).join("")}</ul>`
+        const inv = Hud.inventoryModel(runtime);
+        const itemsHtml = inv.items.length
+            ? `<ul class="inv-items">${inv.items.map((item) => `<li>💰 ${escapeHtml(item)}</li>`).join("")}</ul>`
             : `<p class="inv-empty kind-dim">No treasures yet — explore rooms and grab the loot.</p>`;
         dom.inventory.innerHTML =
-            `<p class="inv-hp">HP <span class="${hp > 40 ? "kind-success" : "kind-error"}">${bar}</span> ${hp}/100</p>`
-            + `<p class="inv-heading kind-dim">Items carried (${items.length})</p>`
+            `<p class="inv-hp">HP <span class="${inv.hp > 40 ? "kind-success" : "kind-error"}">${inv.hpBar}</span> ${inv.hp}/${inv.hpMax}</p>`
+            + `<p class="inv-heading kind-dim">Items carried (${inv.items.length})</p>`
             + itemsHtml;
     }
 
     function renderRoom() {
-        const meta = runtime.currentRoomMeta();
-        const entries = runtime.entries(runtime.state.cwd, false).map((entry) => {
-            const marker = entry.type === "dir" ? "/" : entry.type === "exec" ? "*" : "";
-            return `${entry.type === "dir" ? "📁" : entry.type === "exec" ? "⚡" : "📄"} ${escapeHtml(entry.name)}${marker}`;
-        }).join("<br>");
+        const room = Hud.roomModel(runtime);
+        const entries = room.entries.map((entry) => (
+            `${entry.icon} ${escapeHtml(entry.name)}${entry.marker}`
+        )).join("<br>");
         // Vignette sits under the room name (before the scrollable entry list)
         // so the ambient mascot stays visible even when contents are long. The
         // "In this room" label distinguishes room contents from carried items.
-        dom.room.innerHTML = `<p><strong>${escapeHtml(meta.title || runtime.state.cwd)}</strong></p><p class="kind-dim">${escapeHtml(runtime.state.cwd)}</p>${roomVignetteHtml()}<p class="room-contents-label kind-dim">In this room</p><p>${entries || "(empty)"}</p>`;
+        dom.room.innerHTML = `<p><strong>${escapeHtml(room.title)}</strong></p><p class="kind-dim">${escapeHtml(room.path)}</p>${roomVignetteHtml(room.vignette)}<p class="room-contents-label kind-dim">In this room</p><p>${entries || "(empty)"}</p>`;
     }
 
-    // ── Generative dungeon map ───────────────────────────────────────────────
-    // A fog-of-war tree built live from the runtime filesystem. Only rooms the
-    // player has entered (visited) and the visible doors leading off them
-    // (their direct dir-children) are drawn, so the map grows organically as the
-    // player explores and never reveals undiscovered or still-hidden areas.
-    function mapJoin(parent, name) {
-        return (parent === "/" ? "" : parent) + "/" + name;
-    }
-
-    function dirChildren(path) {
-        if (!runtime.isDir(path)) return [];
-        return runtime.entries(path, false)
-            .filter((entry) => entry.type === "dir")
-            .map((entry) => mapJoin(path, entry.name));
-    }
-
-    function mapNodeLabel(path, visited) {
-        const name = runtime.basename(path) || path.replace(/^\//, "");
-        const isHere = path === runtime.state.cwd;
-        const cls = isHere ? "map-here" : visited.has(path) ? "map-seen" : "map-fog";
-        const marker = isHere ? " ←" : "";
-        return `<span class="${cls}">${escapeHtml(name)}/</span>${marker}`;
-    }
-
-    function mapBuild(path, prefix, visited, discovered, out) {
-        const kids = dirChildren(path).filter((child) => discovered.has(child));
-        kids.forEach((child, i) => {
-            const last = i === kids.length - 1;
-            out.push(prefix + (last ? "└── " : "├── ") + mapNodeLabel(child, visited));
-            mapBuild(child, prefix + (last ? "    " : "│   "), visited, discovered, out);
-        });
-    }
-
+    // Fog-of-war dungeon map: the tree itself comes from the shared presenter
+    // (Hud.mapModel); this just wraps each row in the css classes.
     function renderMap() {
         if (!dom.map) return;
-        const root = (runtime.world && runtime.world.root) || "/entrance";
-        const visited = new Set(runtime.state.visited || []);
-        visited.add(runtime.state.cwd);
-        const discovered = new Set([root]);
-        for (const node of visited) {
-            discovered.add(node);
-            for (const child of dirChildren(node)) discovered.add(child);
-        }
-        const out = [mapNodeLabel(root, visited)];
-        mapBuild(root, "", visited, discovered, out);
-        const legend = `<p class="map-legend kind-dim">${visited.size} room${visited.size === 1 ? "" : "s"} explored · ← you are here</p>`;
+        const map = Hud.mapModel(runtime);
+        const out = map.rows.map((row) => {
+            const cls = row.here ? "map-here" : row.seen ? "map-seen" : "map-fog";
+            return `${row.prefix}<span class="${cls}">${escapeHtml(row.name)}</span>${row.here ? " ←" : ""}`;
+        });
+        const legend = `<p class="map-legend kind-dim">${map.explored} room${map.explored === 1 ? "" : "s"} explored · ← you are here</p>`;
         dom.map.innerHTML = `<pre class="map-tree" aria-label="Discovered dungeon map">${out.join("\n")}</pre>${legend}`;
     }
 

--- a/web/assets/js/hud.js
+++ b/web/assets/js/hud.js
@@ -1,0 +1,377 @@
+(function (global) {
+    "use strict";
+    // Bashcrawl HUD presenter — the ONE place game state becomes presentation
+    // data. Both renderers consume these models:
+    //
+    //   web/assets/js/game.js        paints them as DOM panels + CSS effects
+    //   termforge/node/host-tty.js   paints them as ANSI panels (tui.js)
+    //
+    // Everything here is plain data out (strings, arrays, {kind,text} lines) —
+    // no DOM, no ANSI, no timers. Models read a live Runtime instance; the
+    // catalogs (ranks, achievements) come from global.BashcrawlRuntime, looked
+    // up at call time so load order only matters relative to game/host code.
+    //
+    // Loaded exactly like runtime.js: classic <script> in the browser,
+    // require()'d for its global side effect by termforge/apps/bashcrawl.js.
+
+    // Optional side objectives, grounded in real, checkable state: each hidden
+    // area is "done" once the player has revealed it (reveals map a visible
+    // path like /entrance/chapel to its dotted source).
+    const SIDE_QUESTS = [
+        { key: "chapel", name: "The Hidden Chapel", hint: "Search for a dotfile and unlock the chapel with grep." },
+        { key: "vault", name: "The Sealed Vault", hint: "Use variables to breach the vault." },
+        { key: "scrap", name: "The Scrapyard", hint: "Find the scrap and master symbolic links." },
+        { key: "rift", name: "The Rift", hint: "Tear open the rift for advanced trials." },
+    ];
+
+    // Box-safe ASCII mascot per area (shared ambience: web room panel and the
+    // terminal sidebar draw the same vignette).
+    const ROOM_VIGNETTES = {
+        entrance: [
+            "  (  )      (  )   ",
+            "  )(   /\\   )(     ",
+            "  ||  /  \\  ||     ",
+            " _||_/    \\_||_    ",
+            "[==||      ||==]   ",
+            "   ''      ''      ",
+        ],
+        cellar: [
+            "   (~)        (~)  ",
+            "  .[ ].      .[ ]. ",
+            "  | | |      | | | ",
+            "  | | |      | | | ",
+            " _|_|_|_    _|_|_|_",
+            " '-----'    '-----'",
+        ],
+        graveyard: [
+            " .---.   __   .---.",
+            " | + |  /  \\  | R |",
+            " |   | |    | |   |",
+            " *web* |    | ~~~~ ",
+            "_|___|_|____|_|___|",
+            "  ~~~     ~~~   ~~~",
+        ],
+        vault: [
+            "      /\\          ",
+            "     /  \\   /\\    ",
+            "    / /\\ \\ /  \\   ",
+            "    \\ \\/ / \\  /   ",
+            "     \\  /   \\/    ",
+            "      \\/  *  .    ",
+        ],
+        rift: [
+            "    . * .   .  *   ",
+            "   *  .-~~~-.  .   ",
+            "  .  /  _    \\ *   ",
+            "  * |  ( o )  | .  ",
+            "   . \\  ~-~  / *   ",
+            "    * '-...-'  .   ",
+        ],
+        deep: [
+            "    *  .   *   .   ",
+            "  .   .-~~~~-.  *  ",
+            "  *  / shadow \\ .  ",
+            "   . \\        / *  ",
+            "  .   '------'  .  ",
+        ],
+    };
+
+    function vignetteKeyForRoom(actualPath, cwd) {
+        const p = String(actualPath || cwd || "");
+        if (p.includes("/.rift") || p.includes("/rift")) return "rift";
+        if (p.includes("/.vault") || p.includes("/vault")) return "vault";
+        if (p.includes("/graveyard") || p.includes("/.chapel") || p.includes("/chapel")) return "graveyard";
+        if (p.includes("/cellar") || p.includes("/armoury") || p.includes("/chamber")) return "cellar";
+        if (p === "/entrance" || p.endsWith("/entrance") || p.includes("/workshop")) return "entrance";
+        return "deep";
+    }
+
+    function roomVignette(runtime) {
+        const actual = runtime.actual ? runtime.actual(runtime.state.cwd) : runtime.state.cwd;
+        const key = vignetteKeyForRoom(actual, runtime.state.cwd);
+        return { key, art: ROOM_VIGNETTES[key] || ROOM_VIGNETTES.deep };
+    }
+
+    function bar(value, max, width) {
+        const w = width || 10;
+        const clamped = Math.max(0, Math.min(max, value));
+        const filled = max > 0 ? Math.round((clamped / max) * w) : 0;
+        return "█".repeat(filled) + "░".repeat(w - filled);
+    }
+
+    function rankFor(xp) {
+        const ranks = global.BashcrawlRuntime.ARENA_RANKS;
+        return ranks.filter((r) => (xp || 0) >= r.min).pop() || ranks[0];
+    }
+
+    // Level curve mirrors the in-game `xp` command: 200 XP per level.
+    function levelFor(xp) {
+        const total = xp || 0;
+        return { level: Math.max(1, 1 + Math.floor(total / 200)), into: total % 200, span: 200 };
+    }
+
+    // Record the current room (and its ancestors, so the trunk is always solid)
+    // into the persisted visited-set that drives the map's fog of war.
+    function ensureVisited(runtime) {
+        const state = runtime.state;
+        const visited = state.visited || (state.visited = []);
+        const seen = new Set(visited);
+        const parts = state.cwd.split("/").filter(Boolean);
+        let acc = "";
+        for (const part of parts) {
+            acc += "/" + part;
+            if (!seen.has(acc)) { visited.push(acc); seen.add(acc); }
+        }
+    }
+
+    // Scalar diff-model: cheap to take before/after a command, feeds diffEvents.
+    function snapshot(runtime) {
+        const s = runtime.state;
+        return {
+            xp: s.xp,
+            hp: s.hp,
+            completed: s.completedQuestIds.length,
+            currentQuestId: s.currentQuestId,
+            inventory: s.inventory.slice(),
+            achievements: (s.achievements || []).length,
+            rankIndex: s.rankIndex || 0,
+            cwd: s.cwd,
+        };
+    }
+
+    // Semantic before/after transitions. Both renderers key their juice off
+    // this: the web maps types to CSS effects, the terminal to toasts/flashes.
+    function diffEvents(prev, next) {
+        const events = [];
+        if (next.completed > prev.completed) {
+            events.push({ type: "quest", text: "✦ QUEST COMPLETE ✦" });
+        }
+        if (next.hp < prev.hp) {
+            events.push({ type: "damage", amount: prev.hp - next.hp, text: `−${prev.hp - next.hp} HP` });
+        }
+        if (next.xp > prev.xp) {
+            events.push({ type: "xp", amount: next.xp - prev.xp, text: `+${next.xp - prev.xp} XP` });
+        }
+        if (next.inventory.length > prev.inventory.length) {
+            const gained = next.inventory.slice(prev.inventory.length);
+            events.push({ type: "item", items: gained, text: `💰 ${gained.join(", ")}` });
+        }
+        if (next.rankIndex > prev.rankIndex) {
+            events.push({ type: "levelup", text: `★ ${rankFor(next.xp).title}` });
+        }
+        return events;
+    }
+
+    function sideQuestDone(runtime, key) {
+        const reveals = runtime.state.reveals || {};
+        return Object.keys(reveals).some((path) => path.endsWith("/" + key));
+    }
+
+    function questStatus(runtime, quest) {
+        if (runtime.state.completedQuestIds.includes(quest.id)) return "done";
+        if (quest.id === runtime.state.currentQuestId) return "active";
+        return "locked";
+    }
+
+    // The quest panel model: at-a-glance current quest + the full main/side log.
+    function questModel(runtime) {
+        const current = runtime.quests[runtime.state.currentQuestId] || null;
+        const rows = runtime.quests.map((quest) => {
+            const status = questStatus(runtime, quest);
+            return {
+                status,
+                icon: status === "done" ? "✅" : status === "active" ? "▶" : "🔒",
+                title: quest.title,
+            };
+        });
+        const side = SIDE_QUESTS.map((s) => {
+            const done = sideQuestDone(runtime, s.key);
+            return { key: s.key, name: s.name, hint: s.hint, done, icon: done ? "✅" : "○" };
+        });
+        return {
+            current: current ? { title: current.title, objective: current.objective } : null,
+            mainDone: runtime.state.completedQuestIds.length,
+            mainTotal: runtime.quests.length,
+            rows,
+            side,
+            sideDone: side.filter((s) => s.done).length,
+            xp: runtime.state.xp,
+        };
+    }
+
+    function inventoryModel(runtime) {
+        const hp = Math.max(0, Math.min(100, runtime.state.hp));
+        return { hp, hpMax: 100, hpBar: bar(hp, 100, 10), items: (runtime.state.inventory || []).slice() };
+    }
+
+    function heroModel(runtime) {
+        const xp = runtime.state.xp || 0;
+        const level = levelFor(xp);
+        return {
+            rank: rankFor(xp).title,
+            xp,
+            level: level.level,
+            into: level.into,
+            span: level.span,
+            xpBar: bar(level.into, level.span, 10),
+            badges: (runtime.state.achievements || []).length,
+            badgeTotal: global.BashcrawlRuntime.ACHIEVEMENTS.length,
+        };
+    }
+
+    function roomModel(runtime) {
+        const meta = runtime.currentRoomMeta();
+        const vignette = roomVignette(runtime);
+        const entries = runtime.entries(runtime.state.cwd, false).map((entry) => ({
+            name: entry.name,
+            type: entry.type,
+            icon: entry.type === "dir" ? "📁" : entry.type === "exec" ? "⚡" : "📄",
+            marker: entry.type === "dir" ? "/" : entry.type === "exec" ? "*" : "",
+        }));
+        return { title: meta.title || runtime.state.cwd, path: runtime.state.cwd, vignette, entries };
+    }
+
+    // ── Fog-of-war dungeon map ──────────────────────────────────────────────
+    // Built live from the runtime filesystem: only visited rooms and the doors
+    // leading off them (their direct dir-children) are drawn, so the map grows
+    // organically and never reveals undiscovered or still-hidden areas.
+    function mapJoin(parent, name) {
+        return (parent === "/" ? "" : parent) + "/" + name;
+    }
+
+    function dirChildren(runtime, path) {
+        if (!runtime.isDir(path)) return [];
+        return runtime.entries(path, false)
+            .filter((entry) => entry.type === "dir")
+            .map((entry) => mapJoin(path, entry.name));
+    }
+
+    // Rows: {prefix, name, path, here, seen}. `seen` false = frontier room the
+    // player has glimpsed (a visible door) but not entered — render as fog.
+    function mapModel(runtime) {
+        const root = (runtime.world && runtime.world.root) || "/entrance";
+        const visited = new Set(runtime.state.visited || []);
+        visited.add(runtime.state.cwd);
+        const discovered = new Set([root]);
+        for (const node of visited) {
+            discovered.add(node);
+            for (const child of dirChildren(runtime, node)) discovered.add(child);
+        }
+        const rows = [];
+        const node = (path, prefix) => ({
+            prefix,
+            path,
+            name: (runtime.basename(path) || path.replace(/^\//, "")) + "/",
+            here: path === runtime.state.cwd,
+            seen: visited.has(path),
+        });
+        rows.push(node(root, ""));
+        const build = (path, prefix) => {
+            const kids = dirChildren(runtime, path).filter((child) => discovered.has(child));
+            kids.forEach((child, i) => {
+                const last = i === kids.length - 1;
+                rows.push(node(child, prefix + (last ? "└── " : "├── ")));
+                build(child, prefix + (last ? "    " : "│   "));
+            });
+        };
+        build(root, "");
+        return { rows, explored: visited.size };
+    }
+
+    // ── Terminal panel spec ─────────────────────────────────────────────────
+    // Pre-formatted {title, lines:[{kind,text}]} panels for byte-stream hosts
+    // (tui.js draws them verbatim). Kinds reuse the log palette so the sidebar
+    // matches the web theme's colors.
+    function truncate(text, width) {
+        const chars = Array.from(String(text));
+        return chars.length > width ? chars.slice(0, Math.max(0, width - 1)).join("") + "…" : text;
+    }
+
+    function panels(runtime, options) {
+        const width = (options && options.width) || 30;
+        const hero = heroModel(runtime);
+        const inv = inventoryModel(runtime);
+        const quest = questModel(runtime);
+        const room = roomModel(runtime);
+        const map = mapModel(runtime);
+
+        const heroLines = [
+            { kind: "magic", text: truncate(hero.rank, width) },
+            { kind: "info", text: `Lv ${hero.level}  ${hero.xpBar} ${hero.into}/${hero.span}` },
+            { kind: "dim", text: `${hero.xp} XP · ${hero.badges}/${hero.badgeTotal} badges` },
+        ];
+
+        const hpKind = inv.hp > 40 ? "success" : "error";
+        const vitalLines = [
+            { kind: hpKind, text: `HP ${inv.hpBar} ${inv.hp}/${inv.hpMax}` },
+        ];
+
+        const questLines = [];
+        if (quest.current) {
+            questLines.push({ kind: "info", text: truncate(quest.current.title, width) });
+            questLines.push({ kind: "dim", text: truncate(quest.current.objective, width) });
+        } else {
+            questLines.push({ kind: "success", text: "All quests complete." });
+        }
+        questLines.push({ kind: "dim", text: `${quest.mainDone}/${quest.mainTotal} main · ${quest.sideDone}/${quest.side.length} side` });
+
+        const packLines = inv.items.length
+            ? inv.items.slice(0, 6).map((item) => ({ kind: "output", text: truncate(`💰 ${item}`, width) }))
+            : [{ kind: "dim", text: "(no treasures yet)" }];
+        if (inv.items.length > 6) {
+            packLines.push({ kind: "dim", text: `…and ${inv.items.length - 6} more` });
+        }
+
+        const mapLines = map.rows.map((row) => ({
+            kind: row.here ? "success" : row.seen ? "output" : "dim",
+            text: truncate(row.prefix + row.name + (row.here ? " ←" : ""), width),
+        }));
+        mapLines.push({ kind: "dim", text: `${map.explored} room${map.explored === 1 ? "" : "s"} explored` });
+
+        const roomLines = [{ kind: "info", text: truncate(room.title, width) }]
+            .concat(room.vignette.art.map((line) => ({ kind: "art", text: truncate(line, width) })));
+
+        return [
+            { title: "⚔ HERO", lines: heroLines },
+            { title: "♥ VITALS", lines: vitalLines },
+            { title: "◆ QUEST", lines: questLines },
+            { title: "▣ PACK", lines: packLines },
+            { title: "☗ MAP", lines: mapLines },
+            { title: "◈ ROOM", lines: roomLines },
+        ];
+    }
+
+    // One-line HUD for narrow terminals (drawn above the log as a strip).
+    function strip(runtime) {
+        const hero = heroModel(runtime);
+        const inv = inventoryModel(runtime);
+        const quest = questModel(runtime);
+        const hpKind = inv.hp > 40 ? "success" : "error";
+        return [
+            { kind: hpKind, text: `♥ ${inv.hpBar} ${inv.hp}  ·  Lv ${hero.level} ${hero.xp}xp  ·  ⚑ ${quest.mainDone}/${quest.mainTotal}  ·  ${runtime.state.cwd}` },
+        ];
+    }
+
+    const api = {
+        SIDE_QUESTS,
+        ROOM_VIGNETTES,
+        vignetteKeyForRoom,
+        roomVignette,
+        bar,
+        rankFor,
+        levelFor,
+        ensureVisited,
+        snapshot,
+        diffEvents,
+        sideQuestDone,
+        questModel,
+        inventoryModel,
+        heroModel,
+        roomModel,
+        mapModel,
+        panels,
+        strip,
+    };
+
+    global.BashcrawlHud = api;
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/web/assets/js/runtime.js
+++ b/web/assets/js/runtime.js
@@ -954,5 +954,5 @@
 
     }
 
-    global.BashcrawlRuntime = { Runtime, defaultState, tokenize };
+    global.BashcrawlRuntime = { Runtime, defaultState, tokenize, ARENA_RANKS, ACHIEVEMENTS };
 })(typeof globalThis !== "undefined" ? globalThis : window);

--- a/web/index.html
+++ b/web/index.html
@@ -201,6 +201,7 @@
     <script src="./assets/js/vendor/termforge/input.js"></script>
     <script src="./assets/js/storage.js"></script>
     <script src="./assets/js/runtime.js"></script>
+    <script src="./assets/js/hud.js"></script>
     <script src="./assets/js/docs.js"></script>
     <script src="./assets/js/reference.js"></script>
     <script src="./assets/js/arcade.js"></script>


### PR DESCRIPTION
## What

The interactive terminal (`make tty-demo`) now gets the same graphical treatment as the web story mode — sidebar panels (hero/vitals/quest/pack/fog-of-war map/room vignette), event toasts, and a live input row — and both surfaces render **one shared presentation engine**.

## How

- **`web/assets/js/hud.js`** (new): the shared `BashcrawlHud` presenter — fog-of-war map model, quest/side-quest log, HP/XP bars, hero rank, room vignettes, and `diffEvents()` (quest/damage/xp/item/levelup). Pure data out; loaded like `runtime.js` (classic script in the browser, `require()`'d by the node app).
- **`game.js`**: thin DOM renderer over the shared models; CSS effects unchanged; banner sourced from the runtime `uiText` deck.
- **`termforge/node/tui.js`** (new): `TuiScreen`, an app-agnostic full-screen ANSI compositor (alt screen, panels, wrapped log, toast row, input row, resize, wide-glyph-aware). Brand-neutral: content arrives as data.
- **`termforge/apps/bashcrawl.js`**: implements the new optional `session.hud()` contract (documented in `docs/termforge/authoring-apps.md`).
- **`termforge/node/host-tty.js`**: HUD auto-activates in a real TTY; `--no-hud` or piped stdio keeps the classic line stream — golden transcripts and scripted use untouched.

## Testing

- 17 new tests: `hud.test.js` (presenter contract over real gameplay in the vm harness) + `tui.test.js` (compositor layout, narrow/tiny fallbacks, toast, wrap/cap).
- Full `make test-js`: 87 pass; golden transcripts byte-identical.
- `make web-test`, `make validate-contracts`, `lint-js`, markdownlint on edited docs: green.
- Web verified in a real browser (Playwright): all panels render from the shared models, zero console errors.
- TTY verified in a real PTY (110×32 frame) locally and live on a Debian server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)